### PR TITLE
feat: Add 9n7d test case

### DIFF
--- a/openTEPES/9n/oT_Data_RESEnergy_9n.csv
+++ b/openTEPES/9n/oT_Data_RESEnergy_9n.csv
@@ -1,2 +1,2 @@
-﻿,,RESEnergy
+,,RESEnergy
 2030,Area1,1000


### PR DESCRIPTION
This PR adds a 9n7d test case that can be solved by HiGHS in a few seconds.

Here's an example of running it:

![image](https://github.com/user-attachments/assets/ba5441f0-012f-4184-8ea6-97818aefe843)

