### PR TITLE
feat: Remove ordered=True and ordered=False

### DIFF
--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -81,9 +81,9 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
         mTEPES.del_component(mTEPES.st)
         mTEPES.del_component(mTEPES.n )
         mTEPES.del_component(mTEPES.n2)
-        mTEPES.st = Set(initialize=mTEPES.stt, ordered=True, doc='stages',      filter=lambda mTEPES,stt: stt in st == stt and mTEPES.pStageWeight[stt] and sum(1 for (p,sc,st,nn) in mTEPES.s2n))
-        mTEPES.n  = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
-        mTEPES.n2 = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
+        mTEPES.st = Set(initialize=mTEPES.stt, doc='stages',      filter=lambda mTEPES,stt: stt in st == stt and mTEPES.pStageWeight[stt] and sum(1 for (p,sc,st,nn) in mTEPES.s2n))
+        mTEPES.n  = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
+        mTEPES.n2 = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
 
         # load levels multiple of cycles for each ESS/generator
         mTEPES.nesc         = [(n,es) for n,es in mTEPES.n*mTEPES.es if mTEPES.n.ord(n) %     mTEPES.pStorageTimeStep [es] == 0]
@@ -162,9 +162,9 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
                     mTEPES.del_component(mTEPES.st)
                     mTEPES.del_component(mTEPES.n )
                     mTEPES.del_component(mTEPES.n2)
-                    mTEPES.st = Set(initialize=mTEPES.stt, ordered=True, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                                    p,sc,stt,nn  in mTEPES.s2n))
-                    mTEPES.n  = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
-                    mTEPES.n2 = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
+                    mTEPES.st = Set(initialize=mTEPES.stt, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                                    p,sc,stt,nn  in mTEPES.s2n))
+                    mTEPES.n  = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
+                    mTEPES.n2 = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
 
                     # load levels multiple of cycles for each ESS/generator
                     mTEPES.nesc         = [(n,es) for n,es in mTEPES.n*mTEPES.es if mTEPES.n.ord(n) %     mTEPES.pStorageTimeStep [es] == 0]
@@ -198,9 +198,9 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
     mTEPES.del_component(mTEPES.st)
     mTEPES.del_component(mTEPES.n )
     mTEPES.del_component(mTEPES.n2)
-    mTEPES.st = Set(initialize=mTEPES.stt, ordered=True, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                                    p,sc,stt,nn  in mTEPES.s2n))
-    mTEPES.n  = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
-    mTEPES.n2 = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
+    mTEPES.st = Set(initialize=mTEPES.stt, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                                    p,sc,stt,nn  in mTEPES.s2n))
+    mTEPES.n  = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
+    mTEPES.n2 = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn:  nn  in mTEPES.nn                               and sum(1 for p,sc,st in mTEPES.ps*mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
 
     # load levels multiple of cycles for each ESS/generator
     mTEPES.nesc         = [(n,es) for n,es in mTEPES.n*mTEPES.es if mTEPES.n.ord(n) %     mTEPES.pStorageTimeStep [es] == 0]

--- a/openTEPES/openTEPES_InputData.py
+++ b/openTEPES/openTEPES_InputData.py
@@ -203,24 +203,24 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     dictSets.load(filename=_path+'/oT_Dict_ZoneToArea_'  +CaseName+'.csv', set='znar', format='set')
     dictSets.load(filename=_path+'/oT_Dict_AreaToRegion_'+CaseName+'.csv', set='arrg', format='set')
 
-    mTEPES.pp   = Set(initialize=dictSets['p'   ], ordered=True,  doc='periods', within=PositiveIntegers)
-    mTEPES.scc  = Set(initialize=dictSets['sc'  ], ordered=True,  doc='scenarios'                       )
-    mTEPES.stt  = Set(initialize=dictSets['st'  ], ordered=True,  doc='stages'                          )
-    mTEPES.nn   = Set(initialize=dictSets['n'   ], ordered=True,  doc='load levels'                     )
-    mTEPES.gg   = Set(initialize=dictSets['g'   ], ordered=False, doc='units'                           )
-    mTEPES.gt   = Set(initialize=dictSets['gt'  ], ordered=False, doc='technologies'                    )
-    mTEPES.nd   = Set(initialize=dictSets['nd'  ], ordered=False, doc='nodes'                           )
-    mTEPES.ni   = Set(initialize=dictSets['nd'  ], ordered=False, doc='nodes'                           )
-    mTEPES.nf   = Set(initialize=dictSets['nd'  ], ordered=False, doc='nodes'                           )
-    mTEPES.zn   = Set(initialize=dictSets['zn'  ], ordered=False, doc='zones'                           )
-    mTEPES.ar   = Set(initialize=dictSets['ar'  ], ordered=False, doc='areas'                           )
-    mTEPES.rg   = Set(initialize=dictSets['rg'  ], ordered=False, doc='regions'                         )
-    mTEPES.cc   = Set(initialize=dictSets['cc'  ], ordered=False, doc='circuits'                        )
-    mTEPES.c2   = Set(initialize=dictSets['cc'  ], ordered=False, doc='circuits'                        )
-    mTEPES.lt   = Set(initialize=dictSets['lt'  ], ordered=False, doc='electric line types'             )
-    mTEPES.ndzn = Set(initialize=dictSets['ndzn'], ordered=False, doc='node to zone'                    )
-    mTEPES.znar = Set(initialize=dictSets['znar'], ordered=False, doc='zone to area'                    )
-    mTEPES.arrg = Set(initialize=dictSets['arrg'], ordered=False, doc='area to region'                  )
+    mTEPES.pp   = Set(initialize=dictSets['p'   ], doc='periods', within=PositiveIntegers)
+    mTEPES.scc  = Set(initialize=dictSets['sc'  ], doc='scenarios'                       )
+    mTEPES.stt  = Set(initialize=dictSets['st'  ], doc='stages'                          )
+    mTEPES.nn   = Set(initialize=dictSets['n'   ], doc='load levels'                     )
+    mTEPES.gg   = Set(initialize=dictSets['g'   ], doc='units'                           )
+    mTEPES.gt   = Set(initialize=dictSets['gt'  ], doc='technologies'                    )
+    mTEPES.nd   = Set(initialize=dictSets['nd'  ], doc='nodes'                           )
+    mTEPES.ni   = Set(initialize=dictSets['nd'  ], doc='nodes'                           )
+    mTEPES.nf   = Set(initialize=dictSets['nd'  ], doc='nodes'                           )
+    mTEPES.zn   = Set(initialize=dictSets['zn'  ], doc='zones'                           )
+    mTEPES.ar   = Set(initialize=dictSets['ar'  ], doc='areas'                           )
+    mTEPES.rg   = Set(initialize=dictSets['rg'  ], doc='regions'                         )
+    mTEPES.cc   = Set(initialize=dictSets['cc'  ], doc='circuits'                        )
+    mTEPES.c2   = Set(initialize=dictSets['cc'  ], doc='circuits'                        )
+    mTEPES.lt   = Set(initialize=dictSets['lt'  ], doc='electric line types'             )
+    mTEPES.ndzn = Set(initialize=dictSets['ndzn'], doc='node to zone'                    )
+    mTEPES.znar = Set(initialize=dictSets['znar'], doc='zone to area'                    )
+    mTEPES.arrg = Set(initialize=dictSets['arrg'], doc='area to region'                  )
 
     try:
         import csv
@@ -230,37 +230,37 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
                 num_lines = sum(1 for _ in reader)
             return num_lines
 
-        mTEPES.rs  = Set(initialize=[], ordered=False, doc='reservoirs'               )
-        mTEPES.r2h = Set(initialize=[], ordered=False, doc='reservoir to hydro'       )
-        mTEPES.h2r = Set(initialize=[], ordered=False, doc='hydro to reservoir'       )
-        mTEPES.r2r = Set(initialize=[], ordered=False, doc='reservoir to reservoir'   )
-        mTEPES.p2r = Set(initialize=[], ordered=False, doc='pumped-hydro to reservoir')
-        mTEPES.r2p = Set(initialize=[], ordered=False, doc='reservoir to pumped-hydro')
+        mTEPES.rs  = Set(initialize=[], doc='reservoirs'               )
+        mTEPES.r2h = Set(initialize=[], doc='reservoir to hydro'       )
+        mTEPES.h2r = Set(initialize=[], doc='hydro to reservoir'       )
+        mTEPES.r2r = Set(initialize=[], doc='reservoir to reservoir'   )
+        mTEPES.p2r = Set(initialize=[], doc='pumped-hydro to reservoir')
+        mTEPES.r2p = Set(initialize=[], doc='reservoir to pumped-hydro')
 
         if count_lines_in_csv(     _path+'/oT_Dict_Reservoir_'             +CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_Reservoir_'             +CaseName+'.csv', set='rs' , format='set')
             mTEPES.del_component(mTEPES.rs)
-            mTEPES.rs  = Set(initialize=dictSets['rs' ], ordered=False, doc='reservoirs'               )
+            mTEPES.rs  = Set(initialize=dictSets['rs' ], doc='reservoirs'               )
         if count_lines_in_csv(     _path+'/oT_Dict_ReservoirToHydro_'      +CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_ReservoirToHydro_'      +CaseName+'.csv', set='r2h', format='set')
             mTEPES.del_component(mTEPES.r2h)
-            mTEPES.r2h = Set(initialize=dictSets['r2h'], ordered=False, doc='reservoir to hydro'       )
+            mTEPES.r2h = Set(initialize=dictSets['r2h'], doc='reservoir to hydro'       )
         if count_lines_in_csv(     _path+'/oT_Dict_HydroToReservoir_'      +CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_HydroToReservoir_'      +CaseName+'.csv', set='h2r', format='set')
             mTEPES.del_component(mTEPES.h2r)
-            mTEPES.h2r = Set(initialize=dictSets['h2r'], ordered=False, doc='hydro to reservoir'       )
+            mTEPES.h2r = Set(initialize=dictSets['h2r'], doc='hydro to reservoir'       )
         if count_lines_in_csv(     _path+'/oT_Dict_ReservoirToReservoir_'  +CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_ReservoirToReservoir_'  +CaseName+'.csv', set='r2r', format='set')
             mTEPES.del_component(mTEPES.r2r)
-            mTEPES.r2r = Set(initialize=dictSets['r2r'], ordered=False, doc='reservoir to reservoir'   )
+            mTEPES.r2r = Set(initialize=dictSets['r2r'], doc='reservoir to reservoir'   )
         if count_lines_in_csv(     _path+'/oT_Dict_PumpedHydroToReservoir_'+CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_PumpedHydroToReservoir_'+CaseName+'.csv', set='p2r', format='set')
             mTEPES.del_component(mTEPES.p2r)
-            mTEPES.p2r = Set(initialize=dictSets['p2r'], ordered=False, doc='pumped-hydro to reservoir')
+            mTEPES.p2r = Set(initialize=dictSets['p2r'], doc='pumped-hydro to reservoir')
         if count_lines_in_csv(     _path+'/oT_Dict_ReservoirToPumpedHydro_'+CaseName+'.csv') > 1:
             dictSets.load(filename=_path+'/oT_Dict_ReservoirToPumpedHydro_'+CaseName+'.csv', set='r2p', format='set')
             mTEPES.del_component(mTEPES.r2p)
-            mTEPES.r2p = Set(initialize=dictSets['r2p'], ordered=False, doc='reservoir to pumped-hydro')
+            mTEPES.r2p = Set(initialize=dictSets['r2p'], doc='reservoir to pumped-hydro')
     except:
         pass
 
@@ -559,64 +559,64 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     sBrList = [(ni,nf) for n,(ni,nf)  in enumerate(sBr) if (ni,nf) not in sBr[:n]]
 
     #%% defining subsets: active load levels (n,n2), thermal units (t), RES units (r), ESS units (es), candidate gen units (gc), candidate ESS units (ec), all the electric lines (la), candidate electric lines (lc), candidate DC electric lines (cd), existing DC electric lines (cd), electric lines with losses (ll), reference node (rf), and reactive generating units (gq)
-    mTEPES.p      = Set(initialize=mTEPES.pp,               ordered=True , doc='periods'                         , filter=lambda mTEPES,pp  : pp     in mTEPES.pp  and pPeriodWeight       [pp] >  0.0 and sum(pDuration[pp,sc,n] for sc,n in mTEPES.scc*mTEPES.nn))
-    mTEPES.sc     = Set(initialize=mTEPES.scc,              ordered=True , doc='scenarios'                       , filter=lambda mTEPES,scc : scc    in mTEPES.scc                                    )
-    mTEPES.ps     = Set(initialize=mTEPES.p*mTEPES.sc,      ordered=True , doc='periods/scenarios'               , filter=lambda mTEPES,p,sc: (p,sc) in mTEPES.p*mTEPES.sc and pScenProb [p,sc] >  0.0 and sum(pDuration[p,sc,n ] for    n in            mTEPES.nn))
-    mTEPES.st     = Set(initialize=mTEPES.stt,              ordered=True , doc='stages'                          , filter=lambda mTEPES,stt : stt    in mTEPES.stt and pStageWeight       [stt] >  0.0)
-    mTEPES.n      = Set(initialize=mTEPES.nn,               ordered=True , doc='load levels'                     , filter=lambda mTEPES,nn  : nn     in mTEPES.nn  and sum(pDuration  [p,sc,nn] for p,sc in mTEPES.ps) > 0)
-    mTEPES.n2     = Set(initialize=mTEPES.nn,               ordered=True , doc='load levels'                     , filter=lambda mTEPES,nn  : nn     in mTEPES.nn  and sum(pDuration  [p,sc,nn] for p,sc in mTEPES.ps) > 0)
-    mTEPES.g      = Set(initialize=mTEPES.gg,               ordered=True , doc='generating              units'   , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and (pRatedMaxPowerElec [gg] >  0.0 or  pRatedMaxCharge[gg] >  0.0 or pRatedMaxPowerHeat    [gg] >  0.0) and pElecGenPeriodIni[gg] <= mTEPES.p.last() and pElecGenPeriodFin[gg] >= mTEPES.p.first() and pGenToNode.reset_index().set_index(['index']).isin(mTEPES.nd)['Node'][gg])  # excludes generators with empty node
-    mTEPES.t      = Set(initialize=mTEPES.g ,               ordered=False, doc='thermal                 units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pRatedLinearOperCost[g ] >  0.0)
-    mTEPES.re     = Set(initialize=mTEPES.g ,               ordered=False, doc='RES                     units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pRatedLinearOperCost[g ] == 0.0 and pRatedMaxStorage[g] == 0.0   and pProductionFunctionH2[g ] == 0.0 and pProductionFunctionHeat[g ] == 0.0  and pProductionFunctionHydro[g ] == 0.0)
-    mTEPES.es     = Set(initialize=mTEPES.g ,               ordered=False, doc='ESS                     units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and     (pRatedMaxCharge[g ] >  0.0 or  pRatedMaxStorage[g] >  0.0    or pProductionFunctionH2[g ]  > 0.0  or pProductionFunctionHeat[g ]  > 0.0) and pProductionFunctionHydro[g ] == 0.0)
-    mTEPES.h      = Set(initialize=mTEPES.g ,               ordered=False, doc='hydro                   units'   , filter=lambda mTEPES,g   : g      in mTEPES.g                                                                        and pProductionFunctionH2[g ] == 0.0 and pProductionFunctionHeat[g ] == 0.0  and pProductionFunctionHydro[g ]  > 0.0)
-    mTEPES.el     = Set(initialize=mTEPES.es,               ordered=False, doc='electrolyzer            units'   , filter=lambda mTEPES,es  : es     in mTEPES.es                                                                       and pProductionFunctionH2[es]  > 0.0 and pProductionFunctionHeat[es] == 0.0  and pProductionFunctionHydro[es] == 0.0)
-    mTEPES.hp     = Set(initialize=mTEPES.es,               ordered=False, doc='heat pump & elec boiler units'   , filter=lambda mTEPES,es  : es     in mTEPES.es                                                                       and pProductionFunctionH2[es] == 0.0 and pProductionFunctionHeat[es]  > 0.0  and pProductionFunctionHydro[es] == 0.0)
-    mTEPES.ch     = Set(initialize=mTEPES.g ,               ordered=False, doc='CHP       & fuel boiler units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and                                     pRatedMaxPowerHeat[g ] > 0.0 and pProductionFunctionHeat    [g ] == 0.0)
-    mTEPES.bo     = Set(initialize=mTEPES.ch,               ordered=False, doc='            fuel boiler units'   , filter=lambda mTEPES,ch  : ch     in mTEPES.ch  and pRatedMaxPowerElec  [ch] == 0.0 and pRatedMaxPowerHeat[ch] > 0.0 and pProductionFunctionHeat    [ch] == 0.0)
-    mTEPES.hh     = Set(initialize=mTEPES.bo,               ordered=False, doc='        hydrogen boiler units'   , filter=lambda mTEPES,bo  : bo     in mTEPES.bo                                                                       and pProductionFunctionH2ToHeat[bo] >  0.0)
-    mTEPES.gc     = Set(initialize=mTEPES.g ,               ordered=False, doc='candidate               units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pGenInvestCost      [g ] >  0.0)
-    mTEPES.gd     = Set(initialize=mTEPES.g ,               ordered=False, doc='retirement              units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pGenRetireCost      [g ] >  0.0)
-    mTEPES.ec     = Set(initialize=mTEPES.es,               ordered=False, doc='candidate ESS           units'   , filter=lambda mTEPES,es  : es     in mTEPES.es  and pGenInvestCost      [es] >  0.0)
-    mTEPES.bc     = Set(initialize=mTEPES.bo,               ordered=False, doc='candidate boiler        units'   , filter=lambda mTEPES,bo  : bo     in mTEPES.bo  and pGenInvestCost      [bo] >  0.0)
-    mTEPES.br     = Set(initialize=sBrList,                 ordered=False, doc='all input       electric branches'                                                                                    )
-    mTEPES.ln     = Set(initialize=dfNetwork.index,         ordered=False, doc='all input       electric lines'                                                                                       )
-    mTEPES.la     = Set(initialize=mTEPES.ln,               ordered=False, doc='all real        electric lines'  , filter=lambda mTEPES,*ln : ln     in mTEPES.ln  and pLineX              [ln] != 0.0 and pLineNTCFrw[ln] > 0.0 and pLineNTCBck[ln] > 0.0 and pElecNetPeriodIni[ln]  <= mTEPES.p.last() and pElecNetPeriodFin[ln]  >= mTEPES.p.first())
-    mTEPES.ls     = Set(initialize=mTEPES.la,               ordered=False, doc='all real switch electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pIndBinLineSwitch   [la]       )
-    mTEPES.lc     = Set(initialize=mTEPES.la,               ordered=False, doc='candidate       electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] >  0.0)
-    mTEPES.cd     = Set(initialize=mTEPES.la,               ordered=False, doc='             DC electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] >  0.0 and pLineType[la] == 'DC')
-    mTEPES.ed     = Set(initialize=mTEPES.la,               ordered=False, doc='             DC electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] == 0.0 and pLineType[la] == 'DC')
-    mTEPES.ll     = Set(initialize=mTEPES.la,               ordered=False, doc='loss            electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pLineLossFactor     [la] >  0.0 and pIndBinNetLosses > 0 )
-    mTEPES.rf     = Set(initialize=mTEPES.nd,               ordered=True , doc='reference node'                  , filter=lambda mTEPES,nd  : nd     in                pReferenceNode                 )
-    mTEPES.gq     = Set(initialize=mTEPES.gg,               ordered=False, doc='gen    reactive units'           , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and pRMaxReactivePower  [gg] >  0.0 and                                                     pElecGenPeriodIni[gg]  <= mTEPES.p.last() and pElecGenPeriodFin[gg]  >= mTEPES.p.first())
-    mTEPES.sq     = Set(initialize=mTEPES.gg,               ordered=False, doc='synchr reactive units'           , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and pRMaxReactivePower  [gg] >  0.0 and pGenToTechnology[gg] == 'SynchronousCondenser'  and pElecGenPeriodIni[gg]  <= mTEPES.p.last() and pElecGenPeriodFin[gg]  >= mTEPES.p.first())
-    mTEPES.sqc    = Set(initialize=mTEPES.sq,               ordered=False, doc='synchr reactive candidate'                                                                                            )
-    mTEPES.shc    = Set(initialize=mTEPES.sq,               ordered=False, doc='shunt           candidate'                                                                                            )
+    mTEPES.p      = Set(initialize=mTEPES.pp,               doc='periods'                         , filter=lambda mTEPES,pp  : pp     in mTEPES.pp  and pPeriodWeight       [pp] >  0.0 and sum(pDuration[pp,sc,n] for sc,n in mTEPES.scc*mTEPES.nn))
+    mTEPES.sc     = Set(initialize=mTEPES.scc,              doc='scenarios'                       , filter=lambda mTEPES,scc : scc    in mTEPES.scc                                    )
+    mTEPES.ps     = Set(initialize=mTEPES.p*mTEPES.sc,      doc='periods/scenarios'               , filter=lambda mTEPES,p,sc: (p,sc) in mTEPES.p*mTEPES.sc and pScenProb [p,sc] >  0.0 and sum(pDuration[p,sc,n ] for    n in            mTEPES.nn))
+    mTEPES.st     = Set(initialize=mTEPES.stt,              doc='stages'                          , filter=lambda mTEPES,stt : stt    in mTEPES.stt and pStageWeight       [stt] >  0.0)
+    mTEPES.n      = Set(initialize=mTEPES.nn,               doc='load levels'                     , filter=lambda mTEPES,nn  : nn     in mTEPES.nn  and sum(pDuration  [p,sc,nn] for p,sc in mTEPES.ps) > 0)
+    mTEPES.n2     = Set(initialize=mTEPES.nn,               doc='load levels'                     , filter=lambda mTEPES,nn  : nn     in mTEPES.nn  and sum(pDuration  [p,sc,nn] for p,sc in mTEPES.ps) > 0)
+    mTEPES.g      = Set(initialize=mTEPES.gg,               doc='generating              units'   , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and (pRatedMaxPowerElec [gg] >  0.0 or  pRatedMaxCharge[gg] >  0.0 or pRatedMaxPowerHeat    [gg] >  0.0) and pElecGenPeriodIni[gg] <= mTEPES.p.last() and pElecGenPeriodFin[gg] >= mTEPES.p.first() and pGenToNode.reset_index().set_index(['index']).isin(mTEPES.nd)['Node'][gg])  # excludes generators with empty node
+    mTEPES.t      = Set(initialize=mTEPES.g ,               doc='thermal                 units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pRatedLinearOperCost[g ] >  0.0)
+    mTEPES.re     = Set(initialize=mTEPES.g ,               doc='RES                     units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pRatedLinearOperCost[g ] == 0.0 and pRatedMaxStorage[g] == 0.0   and pProductionFunctionH2[g ] == 0.0 and pProductionFunctionHeat[g ] == 0.0  and pProductionFunctionHydro[g ] == 0.0)
+    mTEPES.es     = Set(initialize=mTEPES.g ,               doc='ESS                     units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and     (pRatedMaxCharge[g ] >  0.0 or  pRatedMaxStorage[g] >  0.0    or pProductionFunctionH2[g ]  > 0.0  or pProductionFunctionHeat[g ]  > 0.0) and pProductionFunctionHydro[g ] == 0.0)
+    mTEPES.h      = Set(initialize=mTEPES.g ,               doc='hydro                   units'   , filter=lambda mTEPES,g   : g      in mTEPES.g                                                                        and pProductionFunctionH2[g ] == 0.0 and pProductionFunctionHeat[g ] == 0.0  and pProductionFunctionHydro[g ]  > 0.0)
+    mTEPES.el     = Set(initialize=mTEPES.es,               doc='electrolyzer            units'   , filter=lambda mTEPES,es  : es     in mTEPES.es                                                                       and pProductionFunctionH2[es]  > 0.0 and pProductionFunctionHeat[es] == 0.0  and pProductionFunctionHydro[es] == 0.0)
+    mTEPES.hp     = Set(initialize=mTEPES.es,               doc='heat pump & elec boiler units'   , filter=lambda mTEPES,es  : es     in mTEPES.es                                                                       and pProductionFunctionH2[es] == 0.0 and pProductionFunctionHeat[es]  > 0.0  and pProductionFunctionHydro[es] == 0.0)
+    mTEPES.ch     = Set(initialize=mTEPES.g ,               doc='CHP       & fuel boiler units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and                                     pRatedMaxPowerHeat[g ] > 0.0 and pProductionFunctionHeat    [g ] == 0.0)
+    mTEPES.bo     = Set(initialize=mTEPES.ch,               doc='            fuel boiler units'   , filter=lambda mTEPES,ch  : ch     in mTEPES.ch  and pRatedMaxPowerElec  [ch] == 0.0 and pRatedMaxPowerHeat[ch] > 0.0 and pProductionFunctionHeat    [ch] == 0.0)
+    mTEPES.hh     = Set(initialize=mTEPES.bo,               doc='        hydrogen boiler units'   , filter=lambda mTEPES,bo  : bo     in mTEPES.bo                                                                       and pProductionFunctionH2ToHeat[bo] >  0.0)
+    mTEPES.gc     = Set(initialize=mTEPES.g ,               doc='candidate               units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pGenInvestCost      [g ] >  0.0)
+    mTEPES.gd     = Set(initialize=mTEPES.g ,               doc='retirement              units'   , filter=lambda mTEPES,g   : g      in mTEPES.g   and pGenRetireCost      [g ] >  0.0)
+    mTEPES.ec     = Set(initialize=mTEPES.es,               doc='candidate ESS           units'   , filter=lambda mTEPES,es  : es     in mTEPES.es  and pGenInvestCost      [es] >  0.0)
+    mTEPES.bc     = Set(initialize=mTEPES.bo,               doc='candidate boiler        units'   , filter=lambda mTEPES,bo  : bo     in mTEPES.bo  and pGenInvestCost      [bo] >  0.0)
+    mTEPES.br     = Set(initialize=sBrList,                 doc='all input       electric branches'                                                                                    )
+    mTEPES.ln     = Set(initialize=dfNetwork.index,         doc='all input       electric lines'                                                                                       )
+    mTEPES.la     = Set(initialize=mTEPES.ln,               doc='all real        electric lines'  , filter=lambda mTEPES,*ln : ln     in mTEPES.ln  and pLineX              [ln] != 0.0 and pLineNTCFrw[ln] > 0.0 and pLineNTCBck[ln] > 0.0 and pElecNetPeriodIni[ln]  <= mTEPES.p.last() and pElecNetPeriodFin[ln]  >= mTEPES.p.first())
+    mTEPES.ls     = Set(initialize=mTEPES.la,               doc='all real switch electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pIndBinLineSwitch   [la]       )
+    mTEPES.lc     = Set(initialize=mTEPES.la,               doc='candidate       electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] >  0.0)
+    mTEPES.cd     = Set(initialize=mTEPES.la,               doc='             DC electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] >  0.0 and pLineType[la] == 'DC')
+    mTEPES.ed     = Set(initialize=mTEPES.la,               doc='             DC electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pNetFixedCost       [la] == 0.0 and pLineType[la] == 'DC')
+    mTEPES.ll     = Set(initialize=mTEPES.la,               doc='loss            electric lines'  , filter=lambda mTEPES,*la : la     in mTEPES.la  and pLineLossFactor     [la] >  0.0 and pIndBinNetLosses > 0 )
+    mTEPES.rf     = Set(initialize=mTEPES.nd,               doc='reference node'                  , filter=lambda mTEPES,nd  : nd     in                pReferenceNode                 )
+    mTEPES.gq     = Set(initialize=mTEPES.gg,               doc='gen    reactive units'           , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and pRMaxReactivePower  [gg] >  0.0 and                                                     pElecGenPeriodIni[gg]  <= mTEPES.p.last() and pElecGenPeriodFin[gg]  >= mTEPES.p.first())
+    mTEPES.sq     = Set(initialize=mTEPES.gg,               doc='synchr reactive units'           , filter=lambda mTEPES,gg  : gg     in mTEPES.gg  and pRMaxReactivePower  [gg] >  0.0 and pGenToTechnology[gg] == 'SynchronousCondenser'  and pElecGenPeriodIni[gg]  <= mTEPES.p.last() and pElecGenPeriodFin[gg]  >= mTEPES.p.first())
+    mTEPES.sqc    = Set(initialize=mTEPES.sq,               doc='synchr reactive candidate'                                                                                            )
+    mTEPES.shc    = Set(initialize=mTEPES.sq,               doc='shunt           candidate'                                                                                            )
     if pIndHydroTopology == 1:
-        mTEPES.rn = Set(initialize=mTEPES.rs,               ordered=False, doc='candidate reservoirs'            , filter=lambda mTEPES,rs  : rs     in mTEPES.rs  and pRsrInvestCost      [rs] >  0.0 and                                                     pRsrPeriodIni[rs]      <= mTEPES.p.last() and pRsrPeriodFin[rs]      >= mTEPES.p.first())
+        mTEPES.rn = Set(initialize=mTEPES.rs,               doc='candidate reservoirs'            , filter=lambda mTEPES,rs  : rs     in mTEPES.rs  and pRsrInvestCost      [rs] >  0.0 and                                                     pRsrPeriodIni[rs]      <= mTEPES.p.last() and pRsrPeriodFin[rs]      >= mTEPES.p.first())
     else:
-        mTEPES.rn = Set(initialize=[],                      ordered=False, doc='candidate reservoirs')
+        mTEPES.rn = Set(initialize=[],                      doc='candidate reservoirs')
     if pIndHydrogen      == 1:
-        mTEPES.pn = Set(initialize=dfNetworkHydrogen.index, ordered=False, doc='all input hydrogen pipes'                                                                                             )
-        mTEPES.pa = Set(initialize=mTEPES.pn,               ordered=False, doc='all real  hydrogen pipes'        , filter=lambda mTEPES,*pn : pn     in mTEPES.pn  and pH2PipeNTCFrw       [pn] >  0.0 and pH2PipeNTCBck[pn] > 0.0 and                         pH2PipePeriodIni[pn]   <= mTEPES.p.last() and pH2PipePeriodFin[pn]   >= mTEPES.p.first())
-        mTEPES.pc = Set(initialize=mTEPES.pa,               ordered=False, doc='candidate hydrogen pipes'        , filter=lambda mTEPES,*pa : pa     in mTEPES.pa  and pH2PipeFixedCost    [pa] >  0.0)
+        mTEPES.pn = Set(initialize=dfNetworkHydrogen.index, doc='all input hydrogen pipes'                                                                                             )
+        mTEPES.pa = Set(initialize=mTEPES.pn,               doc='all real  hydrogen pipes'        , filter=lambda mTEPES,*pn : pn     in mTEPES.pn  and pH2PipeNTCFrw       [pn] >  0.0 and pH2PipeNTCBck[pn] > 0.0 and                         pH2PipePeriodIni[pn]   <= mTEPES.p.last() and pH2PipePeriodFin[pn]   >= mTEPES.p.first())
+        mTEPES.pc = Set(initialize=mTEPES.pa,               doc='candidate hydrogen pipes'        , filter=lambda mTEPES,*pa : pa     in mTEPES.pa  and pH2PipeFixedCost    [pa] >  0.0)
         # existing hydrogen pipelines (pe)
         mTEPES.pe = mTEPES.pa - mTEPES.pc
     else:
-        mTEPES.pn = Set(initialize=[],                      ordered=False, doc='all input hydrogen pipes')
-        mTEPES.pa = Set(initialize=[],                      ordered=False, doc='all real  hydrogen pipes')
-        mTEPES.pc = Set(initialize=[],                      ordered=False, doc='candidate hydrogen pipes')
+        mTEPES.pn = Set(initialize=[],                      doc='all input hydrogen pipes')
+        mTEPES.pa = Set(initialize=[],                      doc='all real  hydrogen pipes')
+        mTEPES.pc = Set(initialize=[],                      doc='candidate hydrogen pipes')
 
     if pIndHeat        == 1:
-        mTEPES.hn = Set(initialize=dfNetworkHeat.index,     ordered=False, doc='all input heat pipes'                                                                                               )
-        mTEPES.ha = Set(initialize=mTEPES.hn,               ordered=False, doc='all real  heat pipes'          , filter=lambda mTEPES,*hn : hn     in mTEPES.hn  and pHeatPipeNTCFrw     [hn] >  0.0 and pHeatPipeNTCBck[hn] > 0.0 and pHeatPipePeriodIni[hn] <= mTEPES.p.last() and pHeatPipePeriodFin[hn] >= mTEPES.p.first())
-        mTEPES.hc = Set(initialize=mTEPES.ha,               ordered=False, doc='candidate heat pipes'          , filter=lambda mTEPES,*ha : ha     in mTEPES.ha  and pHeatPipeFixedCost  [ha] >  0.0)
+        mTEPES.hn = Set(initialize=dfNetworkHeat.index,     doc='all input heat pipes'                                                                                               )
+        mTEPES.ha = Set(initialize=mTEPES.hn,               doc='all real  heat pipes'          , filter=lambda mTEPES,*hn : hn     in mTEPES.hn  and pHeatPipeNTCFrw     [hn] >  0.0 and pHeatPipeNTCBck[hn] > 0.0 and pHeatPipePeriodIni[hn] <= mTEPES.p.last() and pHeatPipePeriodFin[hn] >= mTEPES.p.first())
+        mTEPES.hc = Set(initialize=mTEPES.ha,               doc='candidate heat pipes'          , filter=lambda mTEPES,*ha : ha     in mTEPES.ha  and pHeatPipeFixedCost  [ha] >  0.0)
         # existing heat pipes (he)
         mTEPES.he = mTEPES.ha - mTEPES.hc
     else:
-        mTEPES.hn = Set(initialize=[],                      ordered=False, doc='all input heat pipes')
-        mTEPES.ha = Set(initialize=[],                      ordered=False, doc='all real  heat pipes')
-        mTEPES.hc = Set(initialize=[],                      ordered=False, doc='candidate heat pipes')
+        mTEPES.hn = Set(initialize=[],                      doc='all input heat pipes')
+        mTEPES.ha = Set(initialize=[],                      doc='all real  heat pipes')
+        mTEPES.hc = Set(initialize=[],                      doc='candidate heat pipes')
 
     # non-RES units, they can be committed and also contribute to the operating reserves
     mTEPES.nr = mTEPES.g - mTEPES.re
@@ -638,7 +638,7 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     pStageToLevel = pStageToLevel.loc[pStageToLevel['level_2'].keys().isin(mTEPES.ps*mTEPES.st)]
     pStageToLevel = pStageToLevel.loc[pStageToLevel['level_2'].isin(mTEPES.n)].reset_index().set_index(['level_0','level_1','Stage','level_2'])
 
-    mTEPES.s2n = Set(initialize=pStageToLevel.index, ordered=False, doc='load level to stage')
+    mTEPES.s2n = Set(initialize=pStageToLevel.index, doc='load level to stage')
     # all the stages must have the same duration
     pStageDuration = pd.Series([sum(pDuration[p,sc,n] for p,sc,st2,n in mTEPES.s2n if st2 == st) for st in mTEPES.st], index=mTEPES.st)
     # for st in mTEPES.st:
@@ -648,8 +648,8 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     # delete all the load level belonging to stages with duration equal to zero
     mTEPES.del_component(mTEPES.n )
     mTEPES.del_component(mTEPES.n2)
-    mTEPES.n  = Set(initialize=mTEPES.nn, ordered=True, doc='load levels', filter=lambda mTEPES,nn: nn in mTEPES.nn and sum(pDuration[p,sc,nn] for p,sc in mTEPES.ps) > 0)
-    mTEPES.n2 = Set(initialize=mTEPES.nn, ordered=True, doc='load levels', filter=lambda mTEPES,nn: nn in mTEPES.nn and sum(pDuration[p,sc,nn] for p,sc in mTEPES.ps) > 0)
+    mTEPES.n  = Set(initialize=mTEPES.nn, doc='load levels', filter=lambda mTEPES,nn: nn in mTEPES.nn and sum(pDuration[p,sc,nn] for p,sc in mTEPES.ps) > 0)
+    mTEPES.n2 = Set(initialize=mTEPES.nn, doc='load levels', filter=lambda mTEPES,nn: nn in mTEPES.nn and sum(pDuration[p,sc,nn] for p,sc in mTEPES.ps) > 0)
     # instrumental sets
     def CreateInstrumentalSets(mTEPES, pIndHydroTopology, pIndHydrogen, pIndHeat) -> None:
         '''
@@ -783,23 +783,23 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
         pIndBinHeatPipeInvest = pIndBinHeatPipeInvest.map(idxDict)
 
     # define AC existing  lines     non-switchable
-    mTEPES.lea = Set(initialize=mTEPES.le, ordered=False, doc='AC existing  lines and non-switchable lines', filter=lambda mTEPES,*le: le in mTEPES.le and  pIndBinLineSwitch[le] == 0                             and not pLineType[le] == 'DC')
+    mTEPES.lea = Set(initialize=mTEPES.le, doc='AC existing  lines and non-switchable lines', filter=lambda mTEPES,*le: le in mTEPES.le and  pIndBinLineSwitch[le] == 0                             and not pLineType[le] == 'DC')
     # define AC candidate lines and     switchable lines
-    mTEPES.lca = Set(initialize=mTEPES.la, ordered=False, doc='AC candidate lines and     switchable lines', filter=lambda mTEPES,*la: la in mTEPES.la and (pIndBinLineSwitch[la] == 1 or pNetFixedCost[la] > 0.0) and not pLineType[la] == 'DC')
+    mTEPES.lca = Set(initialize=mTEPES.la, doc='AC candidate lines and     switchable lines', filter=lambda mTEPES,*la: la in mTEPES.la and (pIndBinLineSwitch[la] == 1 or pNetFixedCost[la] > 0.0) and not pLineType[la] == 'DC')
 
     mTEPES.laa = mTEPES.lea | mTEPES.lca
 
     # define DC existing  lines     non-switchable
-    mTEPES.led = Set(initialize=mTEPES.le, ordered=False, doc='DC existing  lines and non-switchable lines', filter=lambda mTEPES,*le: le in mTEPES.le and  pIndBinLineSwitch[le] == 0                             and     pLineType[le] == 'DC')
+    mTEPES.led = Set(initialize=mTEPES.le, doc='DC existing  lines and non-switchable lines', filter=lambda mTEPES,*le: le in mTEPES.le and  pIndBinLineSwitch[le] == 0                             and     pLineType[le] == 'DC')
     # define DC candidate lines and     switchable lines
-    mTEPES.lcd = Set(initialize=mTEPES.la, ordered=False, doc='DC candidate lines and     switchable lines', filter=lambda mTEPES,*la: la in mTEPES.la and (pIndBinLineSwitch[la] == 1 or pNetFixedCost[la] > 0.0) and     pLineType[la] == 'DC')
+    mTEPES.lcd = Set(initialize=mTEPES.la, doc='DC candidate lines and     switchable lines', filter=lambda mTEPES,*la: la in mTEPES.la and (pIndBinLineSwitch[la] == 1 or pNetFixedCost[la] > 0.0) and     pLineType[la] == 'DC')
 
     mTEPES.lad = mTEPES.led | mTEPES.lcd
 
     # line type
     pLineType = pLineType.reset_index().set_index(['level_0','level_1','level_2','LineType'])
 
-    mTEPES.pLineType = Set(initialize=pLineType.index, ordered=False, doc='line type')
+    mTEPES.pLineType = Set(initialize=pLineType.index, doc='line type')
 
     if pAnnualDiscRate == 0.0:
         pDiscountedWeight = pd.Series([                        pPeriodWeight[p]                                                                                          for p in mTEPES.p], index=mTEPES.p)
@@ -814,15 +814,15 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     pNodeToGen = pGenToNode.reset_index().set_index('Node').set_axis(['Generator'], axis=1)[['Generator']]
     pNodeToGen = pNodeToGen.loc[pNodeToGen['Generator'].isin(mTEPES.g)].reset_index().set_index(['Node', 'Generator'])
 
-    mTEPES.n2g = Set(initialize=pNodeToGen.index, ordered=False, doc='node   to generator')
+    mTEPES.n2g = Set(initialize=pNodeToGen.index, doc='node   to generator')
 
     pZone2Gen   = [(zn,g) for (nd,g,zn      ) in mTEPES.n2g*mTEPES.zn             if (nd,zn) in mTEPES.ndzn                           ]
     pArea2Gen   = [(ar,g) for (nd,g,zn,ar   ) in mTEPES.n2g*mTEPES.znar           if (nd,zn) in mTEPES.ndzn                           ]
     pRegion2Gen = [(rg,g) for (nd,g,zn,ar,rg) in mTEPES.n2g*mTEPES.znar*mTEPES.rg if (nd,zn) in mTEPES.ndzn and [ar,rg] in mTEPES.arrg]
 
-    mTEPES.z2g = Set(initialize=mTEPES.zn*mTEPES.g, ordered=False, doc='zone   to generator', filter=lambda mTEPES,zn,g: (zn,g) in pZone2Gen  )
-    mTEPES.a2g = Set(initialize=mTEPES.ar*mTEPES.g, ordered=False, doc='area   to generator', filter=lambda mTEPES,ar,g: (ar,g) in pArea2Gen  )
-    mTEPES.r2g = Set(initialize=mTEPES.rg*mTEPES.g, ordered=False, doc='region to generator', filter=lambda mTEPES,rg,g: (rg,g) in pRegion2Gen)
+    mTEPES.z2g = Set(initialize=mTEPES.zn*mTEPES.g, doc='zone   to generator', filter=lambda mTEPES,zn,g: (zn,g) in pZone2Gen  )
+    mTEPES.a2g = Set(initialize=mTEPES.ar*mTEPES.g, doc='area   to generator', filter=lambda mTEPES,ar,g: (ar,g) in pArea2Gen  )
+    mTEPES.r2g = Set(initialize=mTEPES.rg*mTEPES.g, doc='region to generator', filter=lambda mTEPES,rg,g: (rg,g) in pRegion2Gen)
 
     # mTEPES.z2g  = Set(initialize = [(zn,g) for zn,g in mTEPES.zn*mTEPES.g if (zn,g) in pZone2Gen])
 
@@ -830,15 +830,15 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     pTechnologyToGen = pGenToTechnology.reset_index().set_index('Technology').set_axis(['Generator'], axis=1)[['Generator']]
     pTechnologyToGen = pTechnologyToGen.loc[pTechnologyToGen['Generator'].isin(mTEPES.g)].reset_index().set_index(['Technology', 'Generator'])
 
-    mTEPES.t2g = Set(initialize=pTechnologyToGen.index, ordered=False, doc='technology to generator')
+    mTEPES.t2g = Set(initialize=pTechnologyToGen.index, doc='technology to generator')
 
     # ESS and RES technologies
     def Create_ESS_RES_Sets(mTEPES) -> None:
-        mTEPES.ot = Set(initialize=mTEPES.gt, ordered=False, doc='ESS         technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for es in mTEPES.es if (gt,es) in mTEPES.t2g))
-        mTEPES.ht = Set(initialize=mTEPES.gt, ordered=False, doc='hydro       technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for h  in mTEPES.h  if (gt,h ) in mTEPES.t2g))
-        mTEPES.et = Set(initialize=mTEPES.gt, ordered=False, doc='ESS & hydro technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for eh in mTEPES.eh if (gt,eh) in mTEPES.t2g))
-        mTEPES.rt = Set(initialize=mTEPES.gt, ordered=False, doc='    RES     technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for re in mTEPES.re if (gt,re) in mTEPES.t2g))
-        mTEPES.nt = Set(initialize=mTEPES.gt, ordered=False, doc='non-RES     technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for nr in mTEPES.nr if (gt,nr) in mTEPES.t2g))
+        mTEPES.ot = Set(initialize=mTEPES.gt, doc='ESS         technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for es in mTEPES.es if (gt,es) in mTEPES.t2g))
+        mTEPES.ht = Set(initialize=mTEPES.gt, doc='hydro       technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for h  in mTEPES.h  if (gt,h ) in mTEPES.t2g))
+        mTEPES.et = Set(initialize=mTEPES.gt, doc='ESS & hydro technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for eh in mTEPES.eh if (gt,eh) in mTEPES.t2g))
+        mTEPES.rt = Set(initialize=mTEPES.gt, doc='    RES     technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for re in mTEPES.re if (gt,re) in mTEPES.t2g))
+        mTEPES.nt = Set(initialize=mTEPES.gt, doc='non-RES     technologies', filter=lambda mTEPES,gt: gt in mTEPES.gt and sum(1 for nr in mTEPES.nr if (gt,nr) in mTEPES.t2g))
 
         mTEPES.psgt  = Set(initialize=[(p,sc,  gt) for p,sc,  gt in mTEPES.ps *mTEPES.gt if sum(1 for g  in mTEPES.g  if (p,g ) in mTEPES.pg  and (gt,g ) in mTEPES.t2g)])
         mTEPES.psot  = Set(initialize=[(p,sc,  ot) for p,sc,  ot in mTEPES.ps *mTEPES.ot if sum(1 for es in mTEPES.es if (p,es) in mTEPES.pes and (ot,es) in mTEPES.t2g)])
@@ -859,7 +859,7 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     pExclusiveGenToGen = pGenToExclusiveGen.reset_index().set_index('MutuallyExclusive').set_axis(['Generator'], axis=1)[['Generator']]
     pExclusiveGenToGen = pExclusiveGenToGen.loc[pExclusiveGenToGen['Generator'].isin(mTEPES.g)].reset_index().set_index(['MutuallyExclusive', 'Generator'])
 
-    mTEPES.g2g = Set(initialize=pExclusiveGenToGen.index, ordered=False, doc='mutually exclusive generator to generator', filter=lambda mTEPES,gg,g: (gg,g) in mTEPES.g*mTEPES.g)
+    mTEPES.g2g = Set(initialize=pExclusiveGenToGen.index, doc='mutually exclusive generator to generator', filter=lambda mTEPES,gg,g: (gg,g) in mTEPES.g*mTEPES.g)
 
     # minimum and maximum variable power, charge, and storage capacity
     pMinPowerElec  = pVariableMinPowerElec.replace(0.0, pRatedMinPowerElec)
@@ -1998,8 +1998,8 @@ def SettingUpVariables(OptModel, mTEPES):
         # activate only period, scenario, and load levels to formulate
         mTEPES.del_component(mTEPES.st)
         mTEPES.del_component(mTEPES.n )
-        mTEPES.st = Set(initialize=mTEPES.stt, ordered=True, doc='stages',      filter=lambda mTEPES,stt: stt in st == stt and mTEPES.pStageWeight[stt] and sum(1 for (p,sc,st,nn) in mTEPES.s2n))
-        mTEPES.n  = Set(initialize=mTEPES.nn , ordered=True, doc='load levels', filter=lambda mTEPES,nn : nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
+        mTEPES.st = Set(initialize=mTEPES.stt, doc='stages',      filter=lambda mTEPES,stt: stt in st == stt and mTEPES.pStageWeight[stt] and sum(1 for (p,sc,st,nn) in mTEPES.s2n))
+        mTEPES.n  = Set(initialize=mTEPES.nn , doc='load levels', filter=lambda mTEPES,nn : nn  in mTEPES.nn                              and           (p,sc,st,nn) in mTEPES.s2n)
 
         if len(mTEPES.n):
             mTEPES.psn1 = Set(initialize=[(p,sc,n) for p,sc,n in mTEPES.ps*mTEPES.n])
@@ -2047,8 +2047,8 @@ def SettingUpVariables(OptModel, mTEPES):
     # activate all the periods, scenarios, and load levels again
     mTEPES.del_component(mTEPES.st)
     mTEPES.del_component(mTEPES.n )
-    mTEPES.st = Set(initialize=mTEPES.stt, ordered=True, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                    (p,sc,stt,nn) in mTEPES.s2n))
-    mTEPES.n  = Set(initialize=mTEPES.nn,  ordered=True, doc='load levels', filter=lambda mTEPES,nn : nn  in mTEPES.nn                               and sum(1 for st in mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
+    mTEPES.st = Set(initialize=mTEPES.stt, doc='stages',      filter=lambda mTEPES,stt: stt in mTEPES.stt and mTEPES.pStageWeight[stt] and sum(1 for                    (p,sc,stt,nn) in mTEPES.s2n))
+    mTEPES.n  = Set(initialize=mTEPES.nn,  doc='load levels', filter=lambda mTEPES,nn : nn  in mTEPES.nn                               and sum(1 for st in mTEPES.st if (p,sc,st, nn) in mTEPES.s2n))
 
     # fixing the ESS inventory at the end of the following pStorageTimeStep (daily, weekly, monthly) if between storage limits, i.e.,
     # for daily ESS is fixed at the end of the week, for weekly ESS is fixed at the end of the month, for monthly ESS is fixed at the end of the year

--- a/openTEPES/openTEPES_ModelFormulation.py
+++ b/openTEPES/openTEPES_ModelFormulation.py
@@ -1314,8 +1314,8 @@ def NetworkCycles(mTEPES, pIndLogConsole):
     pUniqueCircuits = pUniqueCircuits[pUniqueCircuits['0/1'] == 1]
 
     # unique and parallel circuits of existing lines
-    mTEPES.ucte = Set(initialize=mTEPES.lea, ordered=False, doc='unique   circuits', filter=lambda mTEPES,ni,nf,cc: (ni,nf,cc) in pUniqueCircuits['0/1'    ])
-    mTEPES.pct  = Set(initialize=mTEPES.br , ordered=False, doc='parallel circuits', filter=lambda mTEPES,ni,nf   : (ni,nf   ) in pNoCircuits['No.Circuits'])
+    mTEPES.ucte = Set(initialize=mTEPES.lea, doc='unique   circuits', filter=lambda mTEPES,ni,nf,cc: (ni,nf,cc) in pUniqueCircuits['0/1'    ])
+    mTEPES.pct  = Set(initialize=mTEPES.br , doc='parallel circuits', filter=lambda mTEPES,ni,nf   : (ni,nf   ) in pNoCircuits['No.Circuits'])
     mTEPES.cye  = RangeSet(0,len(mTEPES.nce)-1)
 
     # graph with all AC existing and candidate lines
@@ -1339,10 +1339,10 @@ def NetworkCycles(mTEPES, pIndLogConsole):
     pUniqueCircuits = pUniqueCircuits[pUniqueCircuits['0/1'] == 1]
 
     # unique and parallel circuits of candidate lines
-    mTEPES.uctc = Set(initialize=mTEPES.laa, ordered=False, doc='unique   circuits', filter=lambda mTEPES,ni,nf,cc: (ni,nf,cc) in pUniqueCircuits['0/1'])
+    mTEPES.uctc = Set(initialize=mTEPES.laa, doc='unique   circuits', filter=lambda mTEPES,ni,nf,cc: (ni,nf,cc) in pUniqueCircuits['0/1'])
     mTEPES.cyc  = RangeSet(0,len(mTEPES.ncd)-1)
     # candidate lines included in every cycle
-    mTEPES.lcac = Set(initialize=mTEPES.cyc*mTEPES.lca, ordered=False, doc='AC candidate circuits in a cycle', filter=lambda mTEPES,cyc,ni,nf,cc: (ni,nf) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])) or (nf,ni) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])))
+    mTEPES.lcac = Set(initialize=mTEPES.cyc*mTEPES.lca, doc='AC candidate circuits in a cycle', filter=lambda mTEPES,cyc,ni,nf,cc: (ni,nf) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])) or (nf,ni) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])))
 
     pBigMTheta = pd.DataFrame(0, index=pd.MultiIndex.from_tuples(mTEPES.cyc*mTEPES.lca, names=('No.Cycle', 'NodeI', 'NodeF', 'Circuit')), columns=['rad'])
     # for cyc,nii,nff,ccc in mTEPES.cyc*mTEPES.lca:

--- a/openTEPES/openTEPES_ModelFormulation.py
+++ b/openTEPES/openTEPES_ModelFormulation.py
@@ -1,5 +1,5 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 18, 2024
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - September 20, 2024
 """
 
 import time
@@ -1339,10 +1339,10 @@ def NetworkCycles(mTEPES, pIndLogConsole):
     pUniqueCircuits = pUniqueCircuits[pUniqueCircuits['0/1'] == 1]
 
     # unique and parallel circuits of candidate lines
-    mTEPES.uctc = Set(initialize=mTEPES.laa, doc='unique   circuits', filter=lambda mTEPES,ni,nf,cc: (ni,nf,cc) in pUniqueCircuits['0/1'])
+    mTEPES.uctc = Set(doc='unique   circuits', initialize=[laa for laa in mTEPES.laa if laa in pUniqueCircuits['0/1']])
     mTEPES.cyc  = RangeSet(0,len(mTEPES.ncd)-1)
     # candidate lines included in every cycle
-    mTEPES.lcac = Set(initialize=mTEPES.cyc*mTEPES.lca, doc='AC candidate circuits in a cycle', filter=lambda mTEPES,cyc,ni,nf,cc: (ni,nf) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])) or (nf,ni) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])))
+    mTEPES.lcac = Set(doc='AC candidate circuits in a cycle', initialize=[(cyc,ni,nf,cc) for cyc,ni,nf,cc in mTEPES.cyc*mTEPES.lca if (ni,nf) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1])) or (nf,ni) in list(zip(mTEPES.ncd[cyc], mTEPES.ncd[cyc][1:] + mTEPES.ncd[cyc][:1]))])
 
     pBigMTheta = pd.DataFrame(0, index=pd.MultiIndex.from_tuples(mTEPES.cyc*mTEPES.lca, names=('No.Cycle', 'NodeI', 'NodeF', 'Circuit')), columns=['rad'])
     # for cyc,nii,nff,ccc in mTEPES.cyc*mTEPES.lca:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -42,4 +42,4 @@ def case_9n_7d_system():
 
 def test_openTEPES_run(case_9n_7d_system):
     mTEPES = openTEPES_run(**case_9n_7d_system)
-    np.testing.assert_approx_equal(pyo.value(mTEPES.eTotalSCost), 6.163409195706696)
+    np.testing.assert_approx_equal(pyo.value(mTEPES.eTotalSCost), 5.575775558785906)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -54,4 +54,4 @@ def case_9n_7d_system():
 def test_openTEPES_run(case_9n_7d_system):
     mTEPES = openTEPES_run(**case_9n_7d_system)
     assert mTEPES is not None
-    np.testing.assert_approx_equal(pyo.value(mTEPES.eTotalSCost), 236.90003485178562)
+    np.testing.assert_approx_equal(pyo.value(mTEPES.eTotalSCost), 249.56217423456937)


### PR DESCRIPTION
This PR removes `ordered=True` and `ordered=False` from all files. This PR also updates the test to be the result of the deterministic process. This should make the `.lp` files deterministic and solutions more deterministic.

With this commit, there's no instances of `ordered=` in the repo (screenshot shows result of the test passing and searching for `ordered` in the `openTEPES` folder):

![image](https://github.com/user-attachments/assets/04dbfce3-fb93-4875-801a-4810bfba5a8e)

Fixes #63 