### PR TITLE
add 'How to Cite' section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,28 @@ Scripts are provided to exchange information with Integrated Assessment Models (
 
 It has been used by the **Ministry for the Ecological Transition and the Demographic Challenge (MITECO)** to analyze the electricity sector in the latest Spanish `National Energy and Climate Plan (NECP) Update 2023-2030 <https://www.miteco.gob.es/content/dam/miteco/es/energia/files-1/pniec-2023-2030/PNIEC_2024_240924.pdf>`_ in September 2024.
 
-Reference
+How to Cite
 ############
+If you use openTEPES for a scientific publication, please cite the following paper:
+
 **A. Ramos, E. Quispe, S. Lumbreras** `“OpenTEPES: Open-source Transmission and Generation Expansion Planning” <https://www.sciencedirect.com/science/article/pii/S235271102200053X>`_ SoftwareX 18: June 2022 `10.1016/j.softx.2022.101070 <https://doi.org/10.1016/j.softx.2022.101070>`_.
+
+BibTeX entry:
+**************
+.. code::
+
+  @article{Ramos2022,
+  author = {Andrés Ramos and Erik Quispe and Sara Lumbreras},
+  title = {openTEPES: Open-source Transmission and Generation Expansion Planning},
+  journal = {SoftwareX},
+  volume = {18},
+  pages = {101070},
+  year = {2022},
+  issn = {2352-7110},
+  doi = {https://doi.org/10.1016/j.softx.2022.101070},
+  url = {https://www.sciencedirect.com/science/article/pii/S235271102200053X},
+  }
+
 
 **openTEPES**: `summary presentation <https://pascua.iit.comillas.edu/aramos/openTEPES.pdf>`_, `présentation (French) <https://pascua.iit.comillas.edu/aramos/openTEPES_fr.pdf>`_, and `installation <https://pascua.iit.comillas.edu/aramos/openTEPES_installation.pdf>`_
 


### PR DESCRIPTION
This PR introduces a dedicated "How to Cite" section in the README.rst file, aiming to guide you and other researchers on the appropriate way to acknowledge the openTEPES model in your work.

Previously, the README.rst file included a "Reference" section that provided a citation to the primary scientific paper associated with the model. Based on this, a BibTeX entry has been included to facilitate citation management for those using LaTeX or other reference management tools.