### PR TITLE
feat: Write Pyomo model results to DuckDB 

### DIFF
--- a/openTEPES/openTEPES_OutputResults.py
+++ b/openTEPES/openTEPES_OutputResults.py
@@ -160,7 +160,8 @@ def _write_param_to_db(con, param, name):
     name : str
         Parameter/table name to use in the database.
     """
-    s = pd.Series(param.extract_values(), index=param.extract_values().keys())
+    values = param.extract_values()
+    s = pd.Series(values, index=values.keys())
     df = s.to_frame(name=name).reset_index()
     _set_df(con, f"p_{name}", df)
 


### PR DESCRIPTION
This PR adds a DuckDB export path for solved Pyomo cases.

DuckDB output makes it easier to explore large case results without having to load multiple CSVs. This PR keeps the existing CSV files unchanged.