### PR TITLE
Add Google Colab compatibility test and modernize CI

### DIFF
--- a/.github/workflows/colab-compatibility.yml
+++ b/.github/workflows/colab-compatibility.yml
@@ -1,0 +1,37 @@
+name: Google Colab Compatibility
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  colab-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y glpk-utils
+
+    - name: Install openTEPES
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install pytest highspy
+
+    - name: Check version
+      run: |
+        python -c "import openTEPES; print(openTEPES.__version__)" || echo "No version defined"
+
+    - name: Run tests
+      run: |
+        pytest -vv tests/test_run.py

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
The user wanted to add compatibility testing for Google Colab. I implemented a new GitHub Action specifically for this purpose and modernized the existing `python-app.yml` workflow to ensure all CI runs are aligned with the project's supported Python versions (>=3.11).

---
*PR created automatically by Jules for task [1535768213517139129](https://jules.google.com/task/1535768213517139129) started by @erikfilias*