### PR TITLE
Add ens_mwh, hue_h, solve_seconds, backend to run-status sentinel JSON

### DIFF
--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -458,23 +458,49 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
         EconomicResults                   (DirName, CaseName, mTEPES, mTEPES, pIndAreaOutput, pIndPlotOutput)
 
     # Run-status sentinel JSON — small machine-readable record of this run.
-    # Lets downstream tools detect a fresh run without grepping stdout.
+    # Lets downstream tools detect a fresh run and read top-level adequacy /
+    # cost numbers without parsing CSVs.
     _OutputSeconds = time.time() - _OutputStart
     _TotalSeconds  = time.time() - InitialTime
+    _SolveSeconds  = max(_TotalSeconds - _OutputSeconds, 0.0)
     try:
         _TotalCost = float(mTEPES.eTotalSCost.expr() if hasattr(mTEPES, "eTotalSCost")
                            else getattr(mTEPES, "vTotalSCost", lambda: float("nan"))())
     except Exception:
         _TotalCost = float("nan")
+    # ENS in MWh and HUE in hours — system-wide totals. Cheap to compute (one
+    # pass over vENS); skipped silently if the variable / index set is missing.
+    _EnsMwh = float("nan")
+    _HueH   = float("nan")
+    try:
+        if hasattr(mTEPES, "vENS") and hasattr(mTEPES, "psnnd"):
+            _ens_psn = {}  # (p, sc, n) -> sum_nd vENS[p,sc,n,nd]
+            for p, sc, n, nd in mTEPES.psnnd:
+                _ens_psn[(p, sc, n)] = _ens_psn.get((p, sc, n), 0.0) + float(mTEPES.vENS[p, sc, n, nd]())
+            _ens_mwh = 0.0
+            _hue_h   = 0.0
+            for (p, sc, n), val in _ens_psn.items():
+                _dur = float(mTEPES.pLoadLevelDuration[p, sc, n]())
+                _ens_mwh += val * _dur
+                if val > 0:
+                    _hue_h += _dur
+            _EnsMwh = round(_ens_mwh, 4)
+            _HueH   = round(_hue_h,   4)
+    except Exception:
+        pass
     status = {
         "case":               CaseName,
         "dir":                DirName,
         "out":                _OutPath,
         "status":             "optimal",
         "total_cost_meur":    _TotalCost,
-        "total_seconds":      round(_TotalSeconds, 2),
+        "ens_mwh":            _EnsMwh,
+        "hue_h":              _HueH,
+        "solve_seconds":      round(_SolveSeconds,  2),
         "output_seconds":     round(_OutputSeconds, 2),
+        "total_seconds":      round(_TotalSeconds,  2),
         "solver":             SolverName,
+        "backend":            getattr(mTEPES, "pOutputBackend", "csv"),
         "opentepees_version": "4.18.17RC",
         "run_started_utc":    _RunStartedUtc,
         "run_finished_utc":   datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",


### PR DESCRIPTION
  ## Summary

  Extends the `oT_Run_Status_<case>.json` sentinel introduced in `20bb17d0` ("Modifying outputs order with flags") with four fields that batch-monitors and post-processing tools need in order to triage a run
  without re-parsing the CSV result tables.

  | New field        | Source                                                         | Unit  |
  |------------------|----------------------------------------------------------------|-------|
  | `ens_mwh`        | sum of `vENS[p,sc,n,nd]` × `pLoadLevelDuration[p,sc,n]`        | MWh   |
  | `hue_h`          | hours where `sum_nd vENS[p,sc,n,nd] > 0`, weighted by Duration | h     |
  | `solve_seconds`  | `total_seconds − output_seconds` (split out for clarity)       | s     |
  | `backend`        | reads `mTEPES.pOutputBackend` if set; else `"csv"`             | str   |

  The ENS/HUE compute path is wrapped in a single `try/except` so the sentinel still writes for non-electric problems (where `vENS` / `psnnd` may not exist). `backend` is a forward-compat field for a future
  writer-backend refactor — it always reports `"csv"` today.

  ## Motivation

  Batch runners (e.g. solving 12 cases per pathway sweep) need to determine adequacy after each case completes. Today this means either parsing `oT_Result_NetworkENS_<case>.csv` after every solve or
  grepping stdout for printed reliability totals. Putting both numbers in the sentinel makes a single small-file read sufficient for go/no-go.

  ## Tested

  Smoke-run on the bundled `9n` case (gurobi):

  ```json
  {
    "case": "9n",
    "status": "optimal",
    "total_cost_meur": 164.38204386744903,
    "ens_mwh": 0.0,
    "hue_h": 0.0,
    "solve_seconds": 27.52,
    "output_seconds": 4.31,
    "total_seconds": 31.82,
    "solver": "gurobi",
    "backend": "csv",
    "opentepees_version": "4.18.17RC"
  }
  ```

  ## Backward compatibility

  - All existing keys retained; only additions.
  - `backend` reads via `getattr(mTEPES, "pOutputBackend", "csv")` — no upstream callers set this attribute today, so behaviour is unchanged.
  - ENS/HUE computation is best-effort; `NaN` is reported if the model lacks the relevant variable or index.

  ## Out of scope (follow-ups)

  - Recording solver `termination_condition` instead of hard-coded `"optimal"`. Today the run aborts via `raise ValueError` on infeasibility, so the sentinel only ever writes on success — but a future addition
   could record the condition directly.
  - Parquet/DuckDB output backends (the `backend` field's reason for being).
