### PR TITLE
feat: add "none" output alias for sentinel-only solves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,13 @@ dmypy.json
 .pyre/
 *.lp
 *.lp
+
+# openTEPES run artifacts (test-case workspace pollution)
+oT_Result_*.csv
+oT_Run_Status_*.json
+oT_Plot_*.png
+oT_Plot_*.html
+*.pid
+
+# Code intelligence index (local tooling)
+.code_intel/

--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -28,6 +28,7 @@ OUTPUT_CATEGORIES = (
 )
 # Aliases expanded inside openTEPES_run.
 OUTPUT_ALIASES = {
+    "none": (),                                              # sentinel-only — for inner-loop / feasibility-check solves
     "min":  ("investment", "summary", "cost", "economic"),
     "full": OUTPUT_CATEGORIES,
 }


### PR DESCRIPTION
 ## Summary
  - Adds `OUTPUT_ALIASES["none"] = ()` so `openTEPES_run(..., results="none")` writes only the run-status sentinel JSON
  — skipping all `oT_Result_*.csv` and plot files.
  - Motivated by inner-loop workflows: D-loop iterations, cross-evaluation sweeps, cost-regret matrices, feasibility
  checks. The sentinel (`ens_mwh`, `hue_h`, `total_cost_meur`, `solve_seconds`, `backend`, added in PR #108) carries
  everything those workflows need; the per-element CSVs are wasted I/O.
  - Bundles a small `.gitignore` extension to cover run artifacts and the local `.code_intel/` index so test runs don't
  leave tracked pollution.

  ## Behaviour
  - `results="full"` and `results="min"` are unchanged.
  - `results="none"` is new and opt-in; default behaviour is untouched.
  - Smoke-tested on `9n` and `sSEP` cases — sentinel JSON written, no other outputs.

  ## Files
  - `openTEPES/openTEPES.py` — single-line addition to `OUTPUT_ALIASES`.
  - `.gitignore` — adds `oT_Result_*.csv`, `oT_Run_Status_*.json`, `oT_Plot_*.{png,html}`, `*.pid`, `.code_intel/`.