### PR TITLE
Fix operator-precedence bug in joint-solve gate

### DIFF
--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -200,12 +200,12 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
                 CycleConstraints                                 (mTEPES, mTEPES, pIndLogConsole, p, sc, st)
 
             # No generator investments and no generator retirements, and no line investments
-            if (    (sum(1 for pp,eb in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2)
-                and (sum(1 for pp,gd in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2)
-                and (sum(1 for pp,rc in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2)
-                and (sum(1 for pp,lc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2)
-                and (sum(1 for pp,pc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2)
-                and (sum(1 for pp,hc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2)):
+            if (    (sum(1 for pp,eb       in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2)
+                and (sum(1 for pp,gd       in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2)
+                and (sum(1 for pp,rc       in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2)
+                and (sum(1 for pp,ni,nf,cc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2)
+                and (sum(1 for pp,ni,nf,cc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2)
+                and (sum(1 for pp,ni,nf,cc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2)):
 
                 # No minimum RES requirements and no emission limit
                 if (max([mTEPES.pRESEnergy[p,ar] for ar in mTEPES.ar]) == 0 and (min([mTEPES.pEmission [p,ar] for ar in mTEPES.ar]) == math.inf or sum(mTEPES.pEmissionRate[nr] for nr in mTEPES.nr) == 0)):
@@ -289,12 +289,12 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
                                 c.deactivate()
 
             # generator investments or generator retirements, or line investments
-            elif (  (sum(1 for pp,eb in mTEPES.peb if pp <= p) > 0 and mTEPES.pIndBinGenInvest()     < 2)
-                 or (sum(1 for pp,gd in mTEPES.pgd if pp <= p) > 0 and mTEPES.pIndBinGenRetire()     < 2)
-                 or (sum(1 for pp,rc in mTEPES.prc if pp <= p) > 0 and mTEPES.pIndBinRsrInvest()     < 2)
-                 or (sum(1 for pp,lc in mTEPES.plc if pp <= p) > 0 and mTEPES.pIndBinNetElecInvest() < 2)
-                 or (sum(1 for pp,pc in mTEPES.ppc if pp <= p) > 0 and mTEPES.pIndBinNetH2Invest()   < 2)
-                 or (sum(1 for pp,hc in mTEPES.phc if pp <= p) > 0 and mTEPES.pIndBinNetHeatInvest() < 2)):
+            elif (  (sum(1 for pp,eb       in mTEPES.peb if pp <= p) > 0 and mTEPES.pIndBinGenInvest()     < 2)
+                 or (sum(1 for pp,gd       in mTEPES.pgd if pp <= p) > 0 and mTEPES.pIndBinGenRetire()     < 2)
+                 or (sum(1 for pp,rc       in mTEPES.prc if pp <= p) > 0 and mTEPES.pIndBinRsrInvest()     < 2)
+                 or (sum(1 for pp,ni,nf,cc in mTEPES.plc if pp <= p) > 0 and mTEPES.pIndBinNetElecInvest() < 2)
+                 or (sum(1 for pp,ni,nf,cc in mTEPES.ppc if pp <= p) > 0 and mTEPES.pIndBinNetH2Invest()   < 2)
+                 or (sum(1 for pp,ni,nf,cc in mTEPES.phc if pp <= p) > 0 and mTEPES.pIndBinNetHeatInvest() < 2)):
 
                     if (p,sc) == mTEPES.ps.last() and st == mTEPES.Last_st and mTEPES.NoRepetition == 0:
                         mTEPES.NoRepetition = 1

--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -200,12 +200,12 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
                 CycleConstraints                                 (mTEPES, mTEPES, pIndLogConsole, p, sc, st)
 
             # No generator investments and no generator retirements, and no line investments
-            if (    sum(1 for pp,eb in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2
-                and sum(1 for pp,gd in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2
-                and sum(1 for pp,rc in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2
-                and sum(1 for pp,lc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2
-                and sum(1 for pp,pc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2
-                and sum(1 for pp,hc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2):
+            if (    (sum(1 for pp,eb in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2)
+                and (sum(1 for pp,gd in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2)
+                and (sum(1 for pp,rc in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2)
+                and (sum(1 for pp,lc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2)
+                and (sum(1 for pp,pc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2)
+                and (sum(1 for pp,hc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2)):
 
                 # No minimum RES requirements and no emission limit
                 if (max([mTEPES.pRESEnergy[p,ar] for ar in mTEPES.ar]) == 0 and (min([mTEPES.pEmission [p,ar] for ar in mTEPES.ar]) == math.inf or sum(mTEPES.pEmissionRate[nr] for nr in mTEPES.nr) == 0)):
@@ -289,12 +289,12 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
                                 c.deactivate()
 
             # generator investments or generator retirements, or line investments
-            elif (  sum(1 for pp,eb in mTEPES.peb if pp <= p) > 0 and mTEPES.pIndBinGenInvest()     < 2
-                 or sum(1 for pp,gd in mTEPES.pgd if pp <= p) > 0 and mTEPES.pIndBinGenRetire()     < 2
-                 or sum(1 for pp,rc in mTEPES.prc if pp <= p) > 0 and mTEPES.pIndBinRsrInvest()     < 2
-                 or sum(1 for pp,lc in mTEPES.plc if pp <= p) > 0 and mTEPES.pIndBinNetElecInvest() < 2
-                 or sum(1 for pp,pc in mTEPES.ppc if pp <= p) > 0 and mTEPES.pIndBinNetH2Invest()   < 2
-                 or sum(1 for pp,hc in mTEPES.phc if pp <= p) > 0 and mTEPES.pIndBinNetHeatInvest() < 2):
+            elif (  (sum(1 for pp,eb in mTEPES.peb if pp <= p) > 0 and mTEPES.pIndBinGenInvest()     < 2)
+                 or (sum(1 for pp,gd in mTEPES.pgd if pp <= p) > 0 and mTEPES.pIndBinGenRetire()     < 2)
+                 or (sum(1 for pp,rc in mTEPES.prc if pp <= p) > 0 and mTEPES.pIndBinRsrInvest()     < 2)
+                 or (sum(1 for pp,lc in mTEPES.plc if pp <= p) > 0 and mTEPES.pIndBinNetElecInvest() < 2)
+                 or (sum(1 for pp,pc in mTEPES.ppc if pp <= p) > 0 and mTEPES.pIndBinNetH2Invest()   < 2)
+                 or (sum(1 for pp,hc in mTEPES.phc if pp <= p) > 0 and mTEPES.pIndBinNetHeatInvest() < 2)):
 
                     if (p,sc) == mTEPES.ps.last() and st == mTEPES.Last_st and mTEPES.NoRepetition == 0:
                         mTEPES.NoRepetition = 1


### PR DESCRIPTION
## Context

Cases configured with at least one investment type set to `Ind*Invest = 0` (active) **and** at least one investment type set to `Ind*Invest = 2` (forbidden) — and with multiple scenarios — are routed through the **per-scenario sequential branch** (lines 213-289) instead of the **with-investment joint branch** (line 292+). The per-scenario branch:

1. Builds operation constraints only for the *current* `(p, sc, st)` (each iteration calls `setattr(OptModel, f'eTotalGCost_{p}_{sc}_{st}', ...)` for that scenario only).
2. Sets `pScenProb[p, sc] = 1.0` (a no-op for the optimisation — `pScenProb[p, sc]()` is read at expression-construction time inside `eTotalTCost`, so it's already frozen at e.g. 0.25).
3. Calls `ProblemSolving`.
4. Resets `pScenProb[p, sc] = 0.0`, deactivates that iteration's named constraints, moves on.
5. Investment vars are then `var.fix(...)`-ed at the first iteration's optimum (`openTEPES_ProblemSolving.py:172-192`), so subsequent iterations re-solve operation-only with iter-1's investment locked in.

Net effect for a 4-scenario probability-weighted run:
- Each iteration solves `min  vTotalICost + 0.25 × op_k + 0` (the other three scenarios' op vars are unconstrained and drop to 0 because they're `NonNegativeReals`).
- Investment is sized for whichever scenario runs first (typically the lexicographically first one, e.g. EP), not for the prob-weighted distribution.
- The sentinel `total_cost_meur = m.eTotalSCost.expr()` written at the end is the *last* iteration's value (a single-scenario op solve with iter-1's invest fixed), not a joint cost.
## Root cause

Python operator precedence: `and` binds tighter than `or`, and there is no parenthesisation. The 6-line condition

```python
if (    sum(1 for pp,eb in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2
    and sum(1 for pp,gd in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2
    and sum(1 for pp,rc in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2
    and sum(1 for pp,lc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2
    and sum(1 for pp,pc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2
    and sum(1 for pp,hc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2):
```

is parsed by Python as

```
(no_eb)                                        OR
(IndGen==2     and no_gd)                      OR
(IndRetire==2  and no_rc)                      OR
(IndRsr==2     and no_lc)                      OR
(IndElec==2    and no_pc)                      OR
(IndH2==2      and no_hc)                      OR
(IndHeat==2)
```

The last term is the giveaway: `IndBinNetHeatInvest == 2` alone makes the whole gate True, regardless of the rest of the model — clearly not the intent.

For our case (peb non-empty, pgd empty, prc empty, plc non-empty, ppc empty, phc empty;
`GenInvest=0, GenRetire=2, RsrInvest=2, NetInvest=0, NetH2=2, NetHeat=2`):

```
ACTUAL  parse: True  → per-scenario sequential branch
INTENDED parse: False → with-investment joint branch (line 292)
```

The mirror gate at line 292-297 (with `> 0` and `< 2`) has the same structure but, for our particular case shape (clauses are all `A_k AND not B_k` joined by `OR`), the broken and intended parses happen to coincide. The 203 misroute alone is enough to silently produce wrong results.

## Fix

Parentheses around each `or` clause so the intended **AND of ORs** structure is preserved:

```python
# No generator investments and no generator retirements, and no line investments
if (    (sum(1 for pp,eb in mTEPES.peb if pp <= p) == 0 or mTEPES.pIndBinGenInvest()     == 2)
    and (sum(1 for pp,gd in mTEPES.pgd if pp <= p) == 0 or mTEPES.pIndBinGenRetire()     == 2)
    and (sum(1 for pp,rc in mTEPES.prc if pp <= p) == 0 or mTEPES.pIndBinRsrInvest()     == 2)
    and (sum(1 for pp,lc in mTEPES.plc if pp <= p) == 0 or mTEPES.pIndBinNetElecInvest() == 2)
    and (sum(1 for pp,pc in mTEPES.ppc if pp <= p) == 0 or mTEPES.pIndBinNetH2Invest()   == 2)
    and (sum(1 for pp,hc in mTEPES.phc if pp <= p) == 0 or mTEPES.pIndBinNetHeatInvest() == 2)):
```

And the symmetric fix at the `elif` on line 292 (each `and` clause parenthesised):

```python
# generator investments or generator retirements, or line investments
elif (  (sum(1 for pp,eb in mTEPES.peb if pp <= p) > 0 and mTEPES.pIndBinGenInvest()     < 2)
     or (sum(1 for pp,gd in mTEPES.pgd if pp <= p) > 0 and mTEPES.pIndBinGenRetire()     < 2)
     or (sum(1 for pp,rc in mTEPES.prc if pp <= p) > 0 and mTEPES.pIndBinRsrInvest()     < 2)
     or (sum(1 for pp,lc in mTEPES.plc if pp <= p) > 0 and mTEPES.pIndBinNetElecInvest() < 2)
     or (sum(1 for pp,pc in mTEPES.ppc if pp <= p) > 0 and mTEPES.pIndBinNetH2Invest()   < 2)
     or (sum(1 for pp,hc in mTEPES.phc if pp <= p) > 0 and mTEPES.pIndBinNetHeatInvest() < 2)):
```

The 292 elif's parses happen to coincide for the AND-of-pairs shape, but the parens make the intent explicit and protect against future edits that might mix in another `and` clause.