### PR TITLE
chore: drop dead Stickler config and unresolvable RTD extras

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,7 +28,4 @@ python:
     install:
     - method: pip
       path: .
-      extra_requirements:
-        - build
-        - docs
     - requirements: doc/md/requirements.txt

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,0 @@
-linters:
-  flake8:
-    fixer: true
-fixers:
-  enable: true


### PR DESCRIPTION
- Remove .stickler.yml: the Stickler CI service is defunct.
- Drop extra_requirements: [build, docs] from .readthedocs.yaml. The legacy flit metadata in pyproject.toml does not declare these extras, so the line silently resolved to nothing. Docs deps continue to come from doc/md/requirements.txt, which is unchanged.