### PR TITLE
Reorder output writers — headline tables first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - [ADDED] opt-in `--gzip-large-csvs` / `--gzip-patterns` CLI flags. After writing, every `oT_Result_*.csv` whose name (after the leading `oT_Result_`) starts with one of the configured prefixes is rewritten as `.csv.gz`. Default prefix set: `Generation, Consumption, Balance, MarketResults, Network`. Pandas reads `.csv.gz` transparently; Excel does not. Sentinel JSON gains `gzip_patterns`, `gzip_files`, `gzip_mb_saved`. Default behaviour unchanged.
+- [CHANGED] reorder output writers in `openTEPES_run` so small KPI/structural tables (`InvestmentResults`, `CostSummaryResults`, `OperationSummaryResults`, `ReliabilityResults`, `FlexibilityResults`) are written before bulky hourly tables (Generation, ESS, Network, Marginal, Economic). HTML map plots run last. Resilient to mid-output interruptions: headline numbers from every solved case survive a kill/timeout/disk-full. No behavioural change beyond write order.
 
 ## [4.18.17RC] - 2026-05-06
 

--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -453,13 +453,30 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
     # Setting on mTEPES avoids changing 14 function signatures.
     mTEPES.pOutputPath = _OutPath
 
-    # output parameters, variables, and duals to CSV files
+    # Output results to CSV files. Writers are ordered so that small,
+    # KPI/structural tables (cost summary, investment decisions, operation
+    # summary, reliability indexes, flexibility metrics) are written FIRST;
+    # bulky hourly tables (Generation/ESS/Network/Marginal/Economic) come
+    # AFTER. If a batch is interrupted mid-output (kill / timeout / disk
+    # full), the headline numbers from every solved case are preserved.
+    # HTML plot writers run LAST.
     _OutputStart = time.time()
-    if pIndDumpRawResults:
-        OutputResultsParVarCon(DirName, CaseName, mTEPES, mTEPES)
 
+    # --- headline tables (small, structural) ---
     if pIndInvestmentResults:
         InvestmentResults                 (DirName, CaseName, mTEPES, mTEPES, pIndTechnologyOutput,                 pIndPlotOutput)
+    if pIndCostSummaryResults:
+        CostSummaryResults                (DirName, CaseName, mTEPES, mTEPES)
+    if pIndOperationSummaryResults:
+        OperationSummaryResults           (DirName, CaseName, mTEPES, mTEPES)
+    if pIndReliabilityResults:
+        ReliabilityResults                (DirName, CaseName, mTEPES, mTEPES)
+    if pIndFlexibilityResults:
+        FlexibilityResults                (DirName, CaseName, mTEPES, mTEPES)
+
+    # --- bulky hourly tables ---
+    if pIndDumpRawResults:
+        OutputResultsParVarCon            (DirName, CaseName, mTEPES, mTEPES)
     if pIndGenerationOperationResults:
         GenerationOperationResults        (DirName, CaseName, mTEPES, mTEPES, pIndTechnologyOutput, pIndAreaOutput, pIndPlotOutput)
         if mTEPES.ch and mTEPES.pIndHeat:
@@ -472,22 +489,16 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
         NetworkH2OperationResults         (DirName, CaseName, mTEPES, mTEPES)
     if pIndNetworkHeatOperationResults and mTEPES.ha and mTEPES.pIndHeat:
         NetworkHeatOperationResults       (DirName, CaseName, mTEPES, mTEPES)
-    if pIndFlexibilityResults:
-        FlexibilityResults                (DirName, CaseName, mTEPES, mTEPES)
-    if pIndReliabilityResults:
-        ReliabilityResults                (DirName, CaseName, mTEPES, mTEPES)
     if pIndNetworkOperationResults:
         NetworkOperationResults           (DirName, CaseName, mTEPES, mTEPES)
-    if pIndNetworkMapResults:
-        NetworkMapResults                 (DirName, CaseName, mTEPES, mTEPES)
-    if pIndOperationSummaryResults:
-        OperationSummaryResults           (DirName, CaseName, mTEPES, mTEPES)
-    if pIndCostSummaryResults:
-        CostSummaryResults                (DirName, CaseName, mTEPES, mTEPES)
     if pIndMarginalResults:
         MarginalResults                   (DirName, CaseName, mTEPES, mTEPES,                 pIndPlotOutput)
     if pIndEconomicResults:
         EconomicResults                   (DirName, CaseName, mTEPES, mTEPES, pIndAreaOutput, pIndPlotOutput)
+
+    # --- plots (slow, not data-critical) ---
+    if pIndNetworkMapResults:
+        NetworkMapResults                 (DirName, CaseName, mTEPES, mTEPES)
 
     # Optional post-write gzip pass. Rewrite every oT_Result_<prefix>*.csv
     # whose <prefix> matches one of the requested patterns as .csv.gz.


### PR DESCRIPTION
  ## Summary
  Reorders the writer dispatch in `openTEPES_run` so headline tables (`InvestmentResults`, `CostSummaryResults`, `OperationSummaryResults`, `ReliabilityResults`, `FlexibilityResults`) are written before bulky hourly tables (Generation/ESS/Network/Marginal/Economic), with `NetworkMapResults` (HTML plots) last.

  ## Why
  If a batch run is interrupted mid-output (kill / timeout / disk full), headline cost/investment/KPI/reliability numbers from every solved case survive. The bulky hourly tables — the ones most likely to be truncated — come last.

  ## Behavioural change
  None. Each `*Results` writer is self-contained (no cross-function state on `mTEPES` / `OptModel`). The diff is a pure block reorder plus three section-separator comments and one header comment explaining the rationale.

  ## Test plan
  - [x] Static introspection: writer call order matches the design.
  - [x] 9n full output
