### PR TITLE
Restore line-switching minimum on/off time parameters

### DIFF
--- a/openTEPES/openTEPES_DataConfiguration.py
+++ b/openTEPES/openTEPES_DataConfiguration.py
@@ -808,8 +808,8 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     par['pLineNTCFrw']              = par['pLineNTCFrw'].loc      [mTEPES.la]
     par['pLineNTCBck']              = par['pLineNTCBck'].loc      [mTEPES.la]
     par['pLineNTCMax']              = par['pLineNTCMax'].loc      [mTEPES.la]
-    # par['pSwOnTime']              = par['pSwOnTime'].loc        [mTEPES.la]
-    # par['pSwOffTime']             = par['pSwOffTime'].loc       [mTEPES.la]
+    par['pSwitchOnTime']            = par['pSwitchOnTime'].loc    [mTEPES.la]
+    par['pSwitchOffTime']           = par['pSwitchOffTime'].loc   [mTEPES.la]
     par['pIndBinLineInvest']        = par['pIndBinLineInvest'].loc[mTEPES.la]
     par['pIndBinLineSwitch']        = par['pIndBinLineSwitch'].loc[mTEPES.la]
     par['pAngMin']                  = par['pAngMin'].loc          [mTEPES.la]
@@ -1164,8 +1164,8 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     mTEPES.pNetFixedCost     = Param(mTEPES.lc,    initialize=par['pNetFixedCost'].to_dict()    , within=NonNegativeReals,    doc='Electric line fixed cost'                                          )
     mTEPES.pIndBinLineInvest = Param(mTEPES.la,    initialize=par['pIndBinLineInvest'].to_dict(), within=Binary          ,    doc='Binary electric line investment decision'                          )
     mTEPES.pIndBinLineSwitch = Param(mTEPES.la,    initialize=par['pIndBinLineSwitch'].to_dict(), within=Binary          ,    doc='Binary electric line switching  decision'                          )
-    # mTEPES.pSwOnTime       = Param(mTEPES.la,    initialize=par['pSwitchOnTime'].to_dict()    , within=NonNegativeIntegers, doc='Minimum switching on  time'                                        )
-    # mTEPES.pSwOffTime      = Param(mTEPES.la,    initialize=par['pSwitchOffTime'].to_dict()   , within=NonNegativeIntegers, doc='Minimum switching off time'                                        )
+    mTEPES.pSwOnTime       = Param(mTEPES.la,    initialize=par['pSwitchOnTime'].to_dict()    , within=NonNegativeIntegers, doc='Minimum switching on  time'                                        )
+    mTEPES.pSwOffTime      = Param(mTEPES.la,    initialize=par['pSwitchOffTime'].to_dict()   , within=NonNegativeIntegers, doc='Minimum switching off time'                                        )
     mTEPES.pBigMFlowBck      = Param(mTEPES.la,    initialize=par['pBigMFlowBck'].to_dict()     , within=NonNegativeReals,    doc='Maximum backward capacity',                            mutable=True)
     mTEPES.pBigMFlowFrw      = Param(mTEPES.la,    initialize=par['pBigMFlowFrw'].to_dict()     , within=NonNegativeReals,    doc='Maximum forward  capacity',                            mutable=True)
     mTEPES.pMaxTheta         = Param(mTEPES.psnnd, initialize=par['pMaxTheta'].to_dict()        , within=NonNegativeReals,    doc='Maximum voltage angle',                                mutable=True)

--- a/openTEPES/openTEPES_InputData.py
+++ b/openTEPES/openTEPES_InputData.py
@@ -418,8 +418,8 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     par['pNetFixedCost']               = dfs['dfNetwork']     ['FixedInvestmentCost'       ] *             dfs['dfNetwork']['FixedChargeRate']           # electric network    fixed cost               [MEUR]
     par['pIndBinLineSwitch']           = dfs['dfNetwork']     ['Switching'                 ]                                                             # binary electric line switching  decision     [Yes]
     par['pIndBinLineInvest']           = dfs['dfNetwork']     ['BinaryInvestment'          ]                                                             # binary electric line investment decision     [Yes]
-    # par['pSwitchOnTime']               = dfs['dfNetwork']     ['SwOnTime'                  ].astype('int')                                               # minimum on  time                             [h]
-    # par['pSwitchOffTime']              = dfs['dfNetwork']     ['SwOffTime'                 ].astype('int')                                               # minimum off time                             [h]
+    par['pSwitchOnTime']               = (dfs['dfNetwork']['SwOnTime' ].astype('int') if 'SwOnTime'  in dfs['dfNetwork'].columns else pd.Series(0, index=dfs['dfNetwork'].index, dtype='int'))  # minimum on  time [h]
+    par['pSwitchOffTime']              = (dfs['dfNetwork']['SwOffTime'].astype('int') if 'SwOffTime' in dfs['dfNetwork'].columns else pd.Series(0, index=dfs['dfNetwork'].index, dtype='int'))  # minimum off time [h]
     par['pAngMin']                     = dfs['dfNetwork']     ['AngMin'                    ] * math.pi / 180                                             # Min phase angle difference                   [rad]
     par['pAngMax']                     = dfs['dfNetwork']     ['AngMax'                    ] * math.pi / 180                                             # Max phase angle difference                   [rad]
     par['pNetLoInvest']                = dfs['dfNetwork']     ['InvestmentLo'              ]                                                             # Lower bound of the investment decision       [p.u.]
@@ -441,9 +441,9 @@ def InputData(DirName, CaseName, mTEPES, pIndLogConsole):
     # replace pNetUpInvest = 0.0 by 1.0
     par['pNetUpInvest']      = par['pNetUpInvest'].where     (par['pNetUpInvest'] > 0.0,   1.0               )
 
-    # minimum up- and downtime converted to an integer number of time steps
-    # par['pSwitchOnTime']  = round(par['pSwitchOnTime'] /par['pTimeStep']).astype('int')
-    # par['pSwitchOffTime'] = round(par['pSwitchOffTime']/par['pTimeStep']).astype('int')
+    # minimum switching on/off time converted to an integer number of time steps
+    par['pSwitchOnTime']  = round(par['pSwitchOnTime'] /par['pTimeStep']).astype('int')
+    par['pSwitchOffTime'] = round(par['pSwitchOffTime']/par['pTimeStep']).astype('int')
 
     if par['pIndHydrogen']:
         par['pH2PipeLength']       = dfs['dfNetworkHydrogen']['Length'             ]                                                         # hydrogen line length                         [km]


### PR DESCRIPTION
 The switching constraints in openTEPES_ModelFormulationElectricity.py (eLineCommit and the min on/off-time rules) reference mTEPES.pSwOnTime and mTEPES.pSwOffTime, but those parameters were commented out in openTEPES_InputData.py and openTEPES_DataConfiguration.py.

 Any case with a switchable line therefore crashes with AttributeError: 'ConcreteModel' object has no attribute 'pSwOnTime'. 
