### PR TITLE
Accept integer 1/1.0 for the Yes/No option flags

### DIFF
--- a/openTEPES/openTEPES.py
+++ b/openTEPES/openTEPES.py
@@ -203,7 +203,8 @@ def openTEPES_run(DirName, CaseName, SolverName, pIndOutputResults, pIndLogConso
     idxDict        = dict()
     idxDict[0    ] = 0
     idxDict[0.0  ] = 0
-    idxDict[0.0  ] = 0
+    idxDict[1    ] = 1
+    idxDict[1.0  ] = 1
     idxDict['No' ] = 0
     idxDict['NO' ] = 0
     idxDict['no' ] = 0


### PR DESCRIPTION
`openTEPES_run` maps `pIndOutputResults` / `pIndLogConsole` through `idxDict`, which had keys for `0`, `0.0` and the Yes/No strings but **not `1` or `1.0`**. Passing the integer `1` therefore raised `IndexError: list index out of range` at the lookup.

This bit `openTEPES_Runner.run`, whose own default is `pIndOutputResults=1` — so any sweep that wrote results (e.g. with `aggregate_to`) crashed before solving.

Adds the `1` and `1.0` keys (and drops a duplicated `0.0` line). Verified a runner sweep with `pIndOutputResults=1` now solves; the 52 fast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)