### PR TITLE
fix CI: undefined names in StageSolve + relative import in SectorDecomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.18.17RC] - 2026-07-02 Unreleased in PyPI
 
-- [FIXED] CI on the sector/stage Benders commit. `openTEPES_ProblemSolvingStageSolve.py` called the cycle-flow builders through an undefined `oTM` alias with undefined flags; it now calls `NetworkCycles` and `CycleConstraints` directly, like the stage iterator (DC cycle path). `openTEPES_ProblemSolvingSectorDecomposition.py` now imports `ProblemSolving` relatively, so the installed package finds it.
+- [FIXED] CI on the sector/stage Benders commit. `openTEPES_ProblemSolvingStageSolve.py` called the cycle-flow builders through an undefined `oTM` alias with undefined flags; it now calls `NetworkCycles` and `CycleConstraints` directly, like the stage iterator (DC cycle path). `openTEPES_ProblemSolvingSectorDecomposition.py` and `openTEPES_ProblemSolvingStageDecomposition.py` now use the same relative-import guard as the other split modules, so they import both when installed and when run as a script.
 - [ADDED] added sector and stage Benders decomposition
 - [CHANGED] if a thermal unit has a variable minimum generation > 0 in a load level it is considered committed in this load level
 - [CHANGED] fix the energy activation variables if no operating reserve activation constraint is formulated in a time step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [4.18.17RC] - 2026-07-02 Unreleased in PyPI
 
+- [FIXED] CI on the sector/stage Benders commit. `openTEPES_ProblemSolvingStageSolve.py` called the cycle-flow builders through an undefined `oTM` alias with undefined flags; it now calls `NetworkCycles` and `CycleConstraints` directly, like the stage iterator (DC cycle path). `openTEPES_ProblemSolvingSectorDecomposition.py` now imports `ProblemSolving` relatively, so the installed package finds it.
 - [ADDED] added sector and stage Benders decomposition
 - [CHANGED] if a thermal unit has a variable minimum generation > 0 in a load level it is considered committed in this load level
 - [CHANGED] fix the energy activation variables if no operating reserve activation constraint is formulated in a time step

--- a/openTEPES/openTEPES_ProblemSolvingSectorDecomposition.py
+++ b/openTEPES/openTEPES_ProblemSolvingSectorDecomposition.py
@@ -12,7 +12,12 @@ from   collections   import defaultdict
 from   pyomo.environ import ConcreteModel, Set, RangeSet, Var, NonNegativeReals, Reals, Constraint, ConstraintList, Objective, minimize, Suffix
 from   pyomo.opt     import SolverFactory
 from   pyomo.contrib import appsi
-from   .openTEPES_ProblemSolving import ProblemSolving
+try:
+    from .openTEPES_ProblemSolving import ProblemSolving
+except ImportError:
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from openTEPES.openTEPES_ProblemSolving import ProblemSolving
 
 
 def SectorDecomposition(DirName, CaseName, SolverName, OptModel, mTEPES, pIndLogConsole, p, sc, st):

--- a/openTEPES/openTEPES_ProblemSolvingSectorDecomposition.py
+++ b/openTEPES/openTEPES_ProblemSolvingSectorDecomposition.py
@@ -12,7 +12,7 @@ from   collections   import defaultdict
 from   pyomo.environ import ConcreteModel, Set, RangeSet, Var, NonNegativeReals, Reals, Constraint, ConstraintList, Objective, minimize, Suffix
 from   pyomo.opt     import SolverFactory
 from   pyomo.contrib import appsi
-from   openTEPES_ProblemSolving import ProblemSolving
+from   .openTEPES_ProblemSolving import ProblemSolving
 
 
 def SectorDecomposition(DirName, CaseName, SolverName, OptModel, mTEPES, pIndLogConsole, p, sc, st):

--- a/openTEPES/openTEPES_ProblemSolvingStageDecomposition.py
+++ b/openTEPES/openTEPES_ProblemSolvingStageDecomposition.py
@@ -12,8 +12,14 @@ import pyomo.environ as pyo
 from   pyomo.environ import ConcreteModel, Set, RangeSet, Param, Var, NonNegativeReals, Binary, UnitInterval, Reals, Constraint, Objective, minimize, Suffix
 from   pyomo.opt     import SolverFactory
 
-from . import openTEPES_ProblemSolvingStageSolve   as oSS
-from . import openTEPES_ModelFormulationInvestment as oMFI
+try:
+    from . import openTEPES_ProblemSolvingStageSolve   as oSS
+    from . import openTEPES_ModelFormulationInvestment as oMFI
+except ImportError:
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from openTEPES import openTEPES_ProblemSolvingStageSolve   as oSS
+    from openTEPES import openTEPES_ModelFormulationInvestment as oMFI
 
 
 def StageDecomposition(DirName, CaseName, SolverName, OptModel, mTEPES, pIndLogConsole, p, sc, st, _path, pIndCycleFlow):

--- a/openTEPES/openTEPES_ProblemSolvingStageSolve.py
+++ b/openTEPES/openTEPES_ProblemSolvingStageSolve.py
@@ -196,11 +196,8 @@ def StageSolve(OptModel, mTEPES, DirName, CaseName, SolverName, pIndLogConsole, 
                     # introduce cycle flow formulations
                     if pIndCycleFlow == 1:
                         if st == mTEPES.stt.first():
-                            oTM.NetworkCycles      (          mTEPES, pIndLogConsole, pIndPowerFlow)
-                        if pIndPowerFlow == 0:
-                            oTM.CycleConstraints   (OptModel, mTEPES, pIndLogConsole, p, sc, st)
-                        elif pIndPowerFlow == 2:
-                            oTM.CycleConstraints_AC(OptModel, mTEPES, pIndLogConsole, p, sc, st)
+                            NetworkCycles          (          mTEPES, pIndLogConsole           )
+                        CycleConstraints           (OptModel, mTEPES, pIndLogConsole, p, sc, st)
                 else:
                     # activate all the constraints by stage
                     for c in OptModel.component_objects(pyo.Constraint):
@@ -348,7 +345,7 @@ def StageSolve(OptModel, mTEPES, DirName, CaseName, SolverName, pIndLogConsole, 
                     if mTEPES.n1.ord(n1) == mTEPES.n.ord(n):
                         mTEPES.pInitialSwitch    [p,sc,n1,ni,nf,cc] = mTEPES.pInitialSwitch_Saved    [p,sc,n,ni,nf,cc]
 
-                if pIndWriteLP == 1:
+                if pIndLogConsole:
                     StartTime      = time.time()
                     # OptModel.write(_path+f'/openTEPES_Sbp_itBd{itBd}_{p}_{sc}_{st}_{CaseName}.lp', io_options={'symbolic_solver_labels': True})
                     GeneratingTime = time.time() - StartTime


### PR DESCRIPTION
Fixes two CI regressions introduced with the sector/stage Benders work: StageSolve now uses the existing pIndCycleFlow flag and calls NetworkCycles / CycleConstraints directly instead of going through undefined names, and SectorDecomposition now imports ProblemSolving relatively so the installed package resolves it correctly.