### PR TITLE
docs: parameter sweeps, DuckDB I/O, Benders + docs CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,24 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -vv -m solve --timeout=1800 tests/
+
+  # Docs tier: build the Read the Docs site with warnings treated as errors, so
+  # a broken cross-reference, a missing toctree entry, or a bad directive fails
+  # the PR. No solver or model dependency, so it runs once on Linux.
+  docs:
+    name: docs (sphinx build)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install doc dependencies
+        run: pip install -r doc/md/requirements.txt
+
+      - name: Build docs (warnings are errors)
+        run: sphinx-build -b html -W --keep-going doc/md doc/_build/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## [4.18.17RC] - 2026-07-02 Unreleased in PyPI
+## [4.18.17RC] - 2026-07-03 Unreleased in PyPI
 
+- [CHANGED] documentation: new Read the Docs page for parameter sweeps (Modes A/B/C via `openTEPES_Runner` + `openTEPES_Cases` and `resolve`). Document the `output_format` DuckDB result output and the `aggregate` sweep merger in OutputResults, the `.duckdb` input option and the integer form of the Yes/No flags in InputData, and Benders decomposition in Characteristics. No model or behaviour change.
+- [ADDED] a CI `docs` job builds the Read the Docs site with warnings treated as errors, so a broken cross-reference or a missing toctree entry fails the PR; `conf.py` silences only the project's front-matter convention warning.
 - [FIXED] CI on the sector/stage Benders commit. `openTEPES_ProblemSolvingStageSolve.py` called the cycle-flow builders through an undefined `oTM` alias with undefined flags; it now calls `NetworkCycles` and `CycleConstraints` directly, like the stage iterator (DC cycle path). `openTEPES_ProblemSolvingSectorDecomposition.py` and `openTEPES_ProblemSolvingStageDecomposition.py` now use the same relative-import guard as the other split modules, so they import both when installed and when run as a script.
 - [ADDED] added sector and stage Benders decomposition
 - [CHANGED] if a thermal unit has a variable minimum generation > 0 in a load level it is considered committed in this load level

--- a/doc/md/Characteristics.md
+++ b/doc/md/Characteristics.md
@@ -47,3 +47,11 @@ openTEPES documentation master file, created by Andres Ramos
 - **Solver independence**
 
   > Any solver can be used that supports linear and mixed-integer linear programming (LP and MILP), such as Gurobi, CPLEX, CBC, GLPK, and HiGHS. The model is implemented in Python using the Pyomo optimization modeling language, which provides a high-level interface for defining optimization problems and supports multiple solvers.
+
+- **Parameter sweeps** to run the same model over many related cases
+
+  > A single runner drives scenario ensembles and sensitivity studies in three modes, trading set-up cost for reuse: re-read the input per case, re-use one in-memory baseline through an overlay, or re-solve one built model. See {doc}`Sweeps`.
+
+- **Benders decomposition** for transmission expansion (experimental)
+
+  > A classical L-shaped decomposition splits the investment master (line-building decisions) from the operation subproblem, which is solved as an LP whose duals build the Benders cuts. It is off by default and reproduces the joint solution; the sector-decomposition extension is under development.

--- a/doc/md/Download.md
+++ b/doc/md/Download.md
@@ -147,6 +147,8 @@ Then, the **results** are written to the folder named after the case. The result
 >
 > `openTEPES_run(<dir>, <case>, <solver>, <results>, <log>)`
 
+A case can be a CSV directory or a single `.duckdb` file (see {doc}`InputData`). To run many related cases at once — scenario ensembles or sensitivity sweeps — see {doc}`Sweeps`.
+
 **Run the Tutorial**
 
 It can be run in Binder:

--- a/doc/md/InputData.md
+++ b/doc/md/InputData.md
@@ -6,6 +6,10 @@ openTEPES documentation master file, created by Andres Ramos
 
 All the input files must be in a folder with the name of the case study.
 
+Alternatively, the whole case can be a single `.duckdb` file instead of a folder of CSV files. `openTEPES_run` selects the backend from the path: a directory is read as CSV (the historical default), while a `.duckdb` file is read through the DuckDB backend. DuckDB is an optional dependency, imported only when such a file is opened, so CSV-only setups need nothing extra. Both forms produce byte-identical results and are interchangeable everywhere a case is named.
+
+The `Yes`/`No` option flags below also accept an integer `1` (or `1.0`) in place of `Yes` and `0` in place of `No`.
+
 ## Acronyms
 
 | Acronym | Description                                                                                                                                                                                                                                |

--- a/doc/md/OutputResults.md
+++ b/doc/md/OutputResults.md
@@ -78,7 +78,9 @@ Uganda 2030 Electric System (118 generators, 49 nodes, 205 lines) one scenario w
 
 The model also plots some additional plots.
 
-All the results of the case are saved in a **DuckDB** database. By default, this option is not used, but you can easily activate it by writing pIndDumpRawResults = 1 in lines 324 and 342 of openTEPES.py module.
+The processed result tables can be written as CSV files (the default), a **DuckDB** database, or both. Pass `output_format="csv"`, `"duckdb"`, or `"both"` to `openTEPES_run` (or to `openTEPES_Runner.run`). With DuckDB on, the case also writes one `oT_Results_<CaseName>.duckdb` holding one table per result file. A `"csv"` run is byte-identical to earlier versions, so switching format changes only where the results are stored, not their values. One database per case keeps a parameter sweep single-writer-safe; see {doc}`Sweeps`.
+
+Separately, the raw parameters, variables, and constraints can be dumped to a DuckDB database for debugging by setting `pIndDumpRawResults = 1` in the `openTEPES.py` module. This is off by default.
 
 The CSV output files used for outputting the results are briefly described in the following items.
 

--- a/doc/md/Sweeps.md
+++ b/doc/md/Sweeps.md
@@ -1,0 +1,78 @@
+---
+openTEPES documentation master file, created by Andres Ramos
+---
+
+# Parameter Sweeps
+
+Many studies run the same model over many related cases — scenario ensembles, demand or fuel-cost sweeps, Monte-Carlo samples. **openTEPES** offers three modes for this, trading set-up cost for reuse, all driven by one orchestrator (`openTEPES_Runner.run`). A single-case sweep reproduces a direct `openTEPES_run`.
+
+| Mode | What each worker repeats | Cost per case | When to use |
+| ---- | ------------------------ | ------------- | ----------- |
+| A — pre-build | read input + build + solve | full | cases that differ structurally, each in its own folder |
+| B — in-memory overlay | build + solve (input read once) | build + solve | one baseline perturbed by a scale factor or a table patch |
+| C — post-build hot-swap | solve only (built once) | solve | one built model re-solved over a range of parameter values |
+
+## Mode A — pre-build sweep
+
+Each case reads its own input source, builds its own model, solves, and writes its own results. It is the most general mode: the cases may differ in any way, since nothing is shared between them.
+
+A `Case` names one input source (a CSV case directory **or** a `.duckdb` file) plus an optional output directory and label. Cases that share the same `(dir_name, case_name)` need distinct `out_path` values so their result writers do not collide.
+
+```python
+from openTEPES import openTEPES_Cases, openTEPES_Runner
+
+cases = [
+    openTEPES_Cases.Case("cases", "SE2035_low"),
+    openTEPES_Cases.Case("cases", "SE2035_ref"),
+    openTEPES_Cases.Case("cases", "SE2035_high"),
+]
+
+summary = openTEPES_Runner.run(cases, solver_name="gurobi",
+                               mode="pre-build", backend="multiprocessing", n_workers=8)
+```
+
+`run` returns one summary dict per case, in input order; a case that raises is reported as `status="error"` rather than aborting the sweep. The `backend` is `"serial"` (default), `"multiprocessing"`, or `"joblib"`.
+
+## Mode B — in-memory overlay
+
+When every case starts from one baseline, reading the input for each is wasteful. In Mode B the baseline is read once into RAM (an `InMemorySource`) and each case re-uses it through an **overlay** before rebuilding. An overlay maps a data-table stem (e.g. `"Demand"`) to one of:
+
+- a **scale factor** — multiply the whole table (`{"Demand": 1.05}`);
+- a **`df -> df` callable** — an arbitrary transform of the table;
+- a **replacement DataFrame** — swap the table outright.
+
+```python
+openTEPES_Runner.run(
+    [openTEPES_Cases.Case("cases", "SE2035_base", out_path="out/d105", overlay={"Demand": 1.05}),
+     openTEPES_Cases.Case("cases", "SE2035_base", out_path="out/d110", overlay={"Demand": 1.10})],
+    solver_name="gurobi", mode="in-memory", backend="multiprocessing", n_workers=8)
+```
+
+The input is read once; each worker only rebuilds and solves. An identity overlay reproduces a direct run.
+
+## Mode C — post-build hot-swap
+
+The cheapest mode reuses a single built model — the slowest step on large cases — and only re-solves it, once per overlay. It is driven directly by `openTEPES_ProblemSolvingResolve.resolve`, not through `openTEPES_Runner`.
+
+```python
+from openTEPES.openTEPES_ProblemSolvingResolve import resolve, overlay_scaled
+
+# OptModel is an already-built model (from openTEPES_run's build step)
+results = resolve(OptModel, "gurobi",
+                  overlays=[overlay_scaled(OptModel, "pDemandElec", 1.05),
+                            overlay_scaled(OptModel, "pDemandElec", 1.10)])
+```
+
+Each overlay applies relative to the baseline, which is restored at the end. Only `mutable=True` Params hot-swap, so Mode C sweeps the operational set only — `pDemandElec`, `pENSCost`, `pLinearVarCost`, `pEFOR`, `pReserveMargin`, `pRESEnergy` — while structural and topology Params stay fixed; `overlay_scaled` builds a scale-factor overlay for one of them. Unix only (uses `fork`); Modes A and B cover all platforms.
+
+## Collecting sweep results
+
+`openTEPES_ResultAggregate.aggregate` stacks a sweep's cases into one long table per result, with a leading `case` column, reading either the per-case DuckDB files or the per-case CSV folders:
+
+```python
+from openTEPES.openTEPES_ResultAggregate import aggregate
+
+aggregate(sources=["out/d105", "out/d110"], out_path="out/sweep", to="duckdb")
+```
+
+`openTEPES_Runner.run` can do this in one step with `aggregate_to=...`. Per-case DuckDB output keeps a sweep single-writer-safe (one database per case). See {doc}`OutputResults` for the `output_format` option that writes those per-case DuckDB files.

--- a/doc/md/conf.py
+++ b/doc/md/conf.py
@@ -58,6 +58,12 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Every page's front matter is a plain title string, not a YAML dict, which
+# MyST flags as `myst.topmatter`. That is the project convention, so silence it;
+# a warnings-as-errors build (CI docs job) then fails only on real problems such
+# as a broken cross-reference or a missing toctree entry.
+suppress_warnings = ['myst.topmatter']
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/doc/md/index.md
+++ b/doc/md/index.md
@@ -24,7 +24,7 @@ defined as a set of **dynamic investment decisions for generation, storage, and 
 It is integrated into the [open energy system modeling platform](https://openenergymodels.net/), helping model Europe's energy system, and it is in the list of [energy models published under open source licenses](https://wiki.openmod-initiative.org/wiki/Open_Models).
 It is also part of the [Africa's open energy system modeling toolbox](https://africaenergymodels.net/), which is a suite of open and linked state-of-the-art open-source energy system models for Africa, and of the [African Energy Modelling Network Open-Source Tools](https://africanenergymodelingnetwork.net/en/focus-area-3-open-source-tools-and-data).
 
-Scripts are provided to exchange information with Integrated Assessment Models (IAM) using their [nomenclature and data formats](https://nomenclature-iamc.readthedocs.io/en/stable/).
+Scripts are provided to exchange information with Integrated Assessment Models (IAM) using their [nomenclature and data formats](https://nomenclature-iamc.readthedocs.io/en/stable/); `Tool_openTEPES_TO_IAMC.py` writes the model results in IAMC format.
 
 It has been used by the **Ministry for the Ecological Transition and the Demographic Challenge (MITECO)** to analyze the electricity sector in the latest Spanish [National Energy and Climate Plan (NECP) Update 2023-2030](https://www.miteco.gob.es/content/dam/miteco/es/energia/files-1/pniec-2023-2030/PNIEC_2024_240924.pdf) in September 2024.
 
@@ -58,6 +58,7 @@ MathematicalFormulation.md
 Projects.md
 Papers.md
 Download.md
+Sweeps.md
 QA.md
 ContactUs.md
 ```


### PR DESCRIPTION
Documents shipped-but-undocumented features (sweep runner Modes A/B/C, DuckDB input/output, Benders) and adds a warnings-as-errors docs build to CI.