### PR TITLE
Guard the CHP power-to-heat ratio against division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [4.18.17RC] - 2026-07-09 Unreleased in PyPI
 
+- [FIXED] validate CHP power ranges before building the power-to-heat ratio, raising a clear error instead of a division by zero, and warn on heat demand at a node with no heat generator or pipe
 - [CHANGED] update InputData docs: the CSV<->DuckDB converter tools now exist (drop the "planned" note), with the bundled `9n` DuckDB example.
 - [FIXED] fix syntactic errors in time Benders decomposition modules
 - [FIXED] fix syntactic errors in openTEPES_ModelFormulationElectricity

--- a/openTEPES/openTEPES_DataConfiguration.py
+++ b/openTEPES/openTEPES_DataConfiguration.py
@@ -768,6 +768,20 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     par['pMaxPower2ndBlock']  = par['pMaxPower2ndBlock'].where (par['pMaxPower2ndBlock']  > par['pEpsilon'], 0.0)
     par['pMaxCharge2ndBlock'] = par['pMaxCharge2ndBlock'].where(par['pMaxCharge2ndBlock'] > par['pEpsilon'], 0.0)
 
+    # validate CHP power ranges (boilers exempt) so the power-to-heat ratio below is well defined
+    if par['pIndHeat']:
+        for ch in mTEPES.ch:
+            if ch not in mTEPES.bo:
+                if par['pRatedMaxPowerHeat'][ch] <= par['pRatedMinPowerHeat'][ch]:
+                    raise ValueError(f'### CHP {ch} has a non-positive heat     power range.')
+                if par['pRatedMaxPowerElec'][ch] <= par['pRatedMinPowerElec'][ch]:
+                    raise ValueError(f'### CHP {ch} has a non-positive electric power range.')
+        # heat demand at a node with no heat generator and no heat pipe is skipped by eBalanceHeat
+        pHeatServedNode = {nd for nd,g in mTEPES.n2g if g in mTEPES.chp} | {nd for ni,nf,cc in mTEPES.ha for nd in (ni,nf)}
+        for nd in mTEPES.nd:
+            if nd not in pHeatServedNode and par['pDemandHeat'][nd].max() > 0.0:
+                print(f'### Warning: node {nd} has heat demand but no heat generator or pipe.')
+
     # computation of the power-to-heat ratio of the CHP units
     # heat ratio of boiler units is fixed to 1.0
     par['pPower2HeatRatio']   = pd.Series([1.0 if ch in mTEPES.bo else (par['pRatedMaxPowerElec'][ch]-par['pRatedMinPowerElec'][ch])/(par['pRatedMaxPowerHeat'][ch]-par['pRatedMinPowerHeat'][ch]) for ch in mTEPES.ch], index=mTEPES.ch)

--- a/tests/test_heat_input_validation.py
+++ b/tests/test_heat_input_validation.py
@@ -1,0 +1,53 @@
+"""Input-validation checks for the heat sector in openTEPES_DataConfiguration.
+
+A non-boiler CHP needs a positive electric and heat power range, otherwise the
+power-to-heat ratio (pRatedMaxPowerElec - pRatedMinPowerElec) / (pRatedMaxPowerHeat
+- pRatedMinPowerHeat) is zero or divides by zero, which used to crash later with an
+opaque ZeroDivisionError. The guard now raises a clear error naming the unit.
+
+These tests take the bundled 9n_heat case (pIndHeat=1, one CHP: CHP_4), copy it,
+break one range, and assert the guard fires.
+"""
+import os
+import shutil
+
+import pandas as pd
+import pytest
+
+from openTEPES.openTEPES import openTEPES_run
+
+CASES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "openTEPES", "cases"))
+
+
+def _prepare_case(tmp_path, edit):
+    """Copy 9n_heat into tmp_path under a new name, apply `edit` to the generation frame, return (dir, name)."""
+    name = "9n_bad"
+    case_dir = tmp_path / name
+    shutil.copytree(os.path.join(CASES_DIR, "9n_heat"), case_dir)
+    for f in os.listdir(case_dir):
+        if "9n_heat" in f:
+            os.rename(case_dir / f, case_dir / f.replace("9n_heat", name))
+
+    gen_file = case_dir / f"oT_Data_Generation_{name}.csv"
+    df = pd.read_csv(gen_file, index_col=0)
+    edit(df)
+    df.to_csv(gen_file)
+    return str(tmp_path), name
+
+
+def test_chp_zero_heat_range_raises(tmp_path):
+    def edit(df):
+        df.loc["CHP_4", "MaximumPowerHeat"] = df.loc["CHP_4", "MinimumPowerHeat"]
+
+    DirName, CaseName = _prepare_case(tmp_path, edit)
+    with pytest.raises(ValueError, match=r"### CHP CHP_4 has a non-positive heat"):
+        openTEPES_run(DirName, CaseName, "gurobi", 0, 0)
+
+
+def test_chp_zero_electric_range_raises(tmp_path):
+    def edit(df):
+        df.loc["CHP_4", "MaximumPower"] = df.loc["CHP_4", "MinimumPower"]
+
+    DirName, CaseName = _prepare_case(tmp_path, edit)
+    with pytest.raises(ValueError, match=r"### CHP CHP_4 has a non-positive electric"):
+        openTEPES_run(DirName, CaseName, "gurobi", 0, 0)


### PR DESCRIPTION
**Fixed — unprotected division in `eEnergy2Heat` (line 44).**
- The power-to-heat ratio `(MaxElec - MinElec) / (MaxHeat - MinHeat)` is built in `openTEPES_DataConfiguration` for
  non-boiler CHPs (boilers are fixed to 1.0).
- It is zero if `MaxElec == MinElec`, and its own denominator divides by zero if `MaxHeat == MinHeat`. Degenerate data crashed later with an opaque `ZeroDivisionError`.
- Now the ranges are node with heat demand but no heat generator and no heat pipe is skipped by `eBalanceHeat`, so its demand was silently dropped. Now it prints a warning (non-fatal).

**Tests.** 
- New `tests/test_heat_input_validation.py` proves both range branches fire.
- Solve costs unchanged: 9n
  252.201, 9n_heat 247.196, 9n_H2 259.547.