### PR TITLE
Cap the solver thread count

### DIFF
--- a/openTEPES/openTEPES_Main.py
+++ b/openTEPES/openTEPES_Main.py
@@ -711,6 +711,15 @@ parser.add_argument('--no-plots',                default=False, help="Disable HT
 parser.add_argument('--out',           type=str, default=None,  help="Output directory for oT_Result_*.csv and oT_Plot_*.html. Default: <dir>/<case>.")
 parser.add_argument('--gzip-large-csvs',         default=False, help="After writing results, gzip every oT_Result_*.csv whose name starts with one of the prefixes given by --gzip-patterns. Default: off (CSVs written plain). NOTE: .csv.gz files cannot be opened directly in Excel; pandas reads them natively.", action="store_true")
 parser.add_argument('--gzip-patterns', type=str, default=None,  help=("Comma-separated list of name-prefixes (after the leading 'oT_Result_') selecting which result CSVs to gzip. Used with --gzip-large-csvs. Default: " + ",".join(DEFAULT_GZIP_PATTERNS) + "."))
+def _positive_int(value: str) -> int:
+    n = int(value)
+    if n < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return n
+
+
+parser.add_argument('--threads',       type=_positive_int, default=None,
+                    help="Cap the solver thread count. Default: half of (logical + physical) cores. Also set by OTEPES_THREADS.")
 
 DIR    = os.path.join(os.path.dirname(__file__), "cases")
 CASE   = '9n'
@@ -724,6 +733,10 @@ def main():
     StartTime = time.time()
     # Parsing the arguments
     args = parser.parse_args()
+
+    if args.threads is not None:
+        os.environ["OTEPES_THREADS"] = str(args.threads)   # _threads() reads it, so the flag wins over the variable
+
     if args.dir is None:
         args.dir    = input('Input Dir    Name (Default {}): '.format(DIR))
         if args.dir == '':

--- a/openTEPES/openTEPES_ProblemSolvingTuning.py
+++ b/openTEPES/openTEPES_ProblemSolvingTuning.py
@@ -20,11 +20,19 @@ case-dependent and can regress smaller cases.
 """
 from __future__ import annotations
 
+import os
+
 import psutil
 
 
 def _threads() -> int:
-    """Default thread count: half of (logical + physical) cores, rounded down."""
+    """Thread count for the solver: ``--threads`` or ``OTEPES_THREADS`` when set to a positive integer, else half of the
+    (logical + physical) cores, rounded down. Capping it lets cases run side by side, each taking a slice of the cores
+    instead of all claiming half the machine.
+    """
+    env = os.environ.get("OTEPES_THREADS", "").strip()
+    if env.isdigit() and int(env) > 0:
+        return int(env)
     return int((psutil.cpu_count(logical=True) + psutil.cpu_count(logical=False)) / 2)
 
 

--- a/openTEPES/openTEPES_Runner.py
+++ b/openTEPES/openTEPES_Runner.py
@@ -231,7 +231,12 @@ def run(cases, solver_name, *, mode="pre-build", backend="serial", n_workers=1,
                 records = [_run_one(*args) for args in work]
             elif backend == "multiprocessing":
                 import multiprocessing as mp
-                with mp.Pool(processes=n_workers) as pool:
+                # Start the workers fresh. A forked worker inherits the parent's solver globals, and HiGHS fixes its
+                # thread count on the first solve and then refuses to change it — so a parent that has already solved
+                # would hand the worker a scheduler it cannot resize to its slice of the budget. Mode A re-reads its
+                # inputs per case anyway, so it has nothing to gain from fork.
+                ctx = mp.get_context("spawn")
+                with ctx.Pool(processes=n_workers) as pool:
                     records = pool.starmap(_run_one, work)
             elif backend == "joblib":
                 try:

--- a/openTEPES/openTEPES_Runner.py
+++ b/openTEPES/openTEPES_Runner.py
@@ -16,15 +16,18 @@ import glob
 import json
 import os
 import sys
+from contextlib import contextmanager
 
 try:
     from .openTEPES import openTEPES_run
     from .openTEPES_ResultAggregate import aggregate
+    from .openTEPES_ProblemSolvingTuning import _threads
 except ImportError:
     import sys
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from openTEPES.openTEPES import openTEPES_run
     from openTEPES.openTEPES_ResultAggregate import aggregate
+    from openTEPES.openTEPES_ProblemSolvingTuning import _threads
 
 
 def _status_dir(case):
@@ -110,6 +113,28 @@ def _run_one_in_memory(case, baseline, solver_name, output_spec, gzip_patterns,
     return summary
 
 
+@contextmanager
+def _worker_thread_budget(backend, n_workers):
+    """Give each worker its slice of the thread budget for the duration of the sweep.
+
+    Workers call ``_threads()`` in their own process, so each would otherwise take the full default
+    and the sweep would ask for ``n_workers`` machines. A count the user set is left alone.
+    """
+    chosen = os.environ.get("OTEPES_THREADS", "").strip()
+    if backend == "serial" or n_workers <= 1 or chosen:
+        yield
+        return
+    previous = os.environ.get("OTEPES_THREADS")
+    os.environ["OTEPES_THREADS"] = str(max(1, _threads() // n_workers))
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("OTEPES_THREADS", None)
+        else:
+            os.environ["OTEPES_THREADS"] = previous
+
+
 def _run_in_memory(cases, solver_name, *, backend, n_workers, output_spec, gzip_patterns,
                    pIndOutputResults, pIndLogConsole, output_format):
     """Mode B dispatch: read each distinct baseline once, then run every case from it. Returns one summary per case."""
@@ -172,6 +197,9 @@ def run(cases, solver_name, *, mode="pre-build", backend="serial", n_workers=1,
     stem to a number / callable / DataFrame, see ``InMemorySource``) and requires a
     distinct ``out_path`` per case.
 
+    A parallel sweep splits the solver thread budget across its ``n_workers``, so they ask for one
+    machine between them, not one each. ``--threads`` / ``OTEPES_THREADS`` overrides that.
+
     ``output_format`` (``"csv"`` / ``"duckdb"`` / ``"both"``) selects each case's
     result format (see ``openTEPES_run``); each worker writes its own per-case
     DuckDB so a parallel sweep stays single-writer-safe. ``aggregate_to``, if set
@@ -181,42 +209,43 @@ def run(cases, solver_name, *, mode="pre-build", backend="serial", n_workers=1,
     """
     cases = list(cases)
 
-    if mode == "in-memory":
-        records = _run_in_memory(
-            cases, solver_name, backend=backend, n_workers=n_workers, output_spec=output_spec,
-            gzip_patterns=gzip_patterns, pIndOutputResults=pIndOutputResults,
-            pIndLogConsole=pIndLogConsole, output_format=output_format,
-        )
-    elif mode == "pre-build":
-        for case in cases:
-            if case.overlay is not None:
-                raise NotImplementedError(
-                    f"Case.overlay is for Mode B (in-memory overlay) and is not supported in Mode A "
-                    f"(mode='pre-build'); case label={case.label!r} set an overlay. Use mode='in-memory'."
-                )
+    with _worker_thread_budget(backend, n_workers):
+        if mode == "in-memory":
+            records = _run_in_memory(
+                cases, solver_name, backend=backend, n_workers=n_workers, output_spec=output_spec,
+                gzip_patterns=gzip_patterns, pIndOutputResults=pIndOutputResults,
+                pIndLogConsole=pIndLogConsole, output_format=output_format,
+            )
+        elif mode == "pre-build":
+            for case in cases:
+                if case.overlay is not None:
+                    raise NotImplementedError(
+                        f"Case.overlay is for Mode B (in-memory overlay) and is not supported in Mode A "
+                        f"(mode='pre-build'); case label={case.label!r} set an overlay. Use mode='in-memory'."
+                    )
 
-        work = [(case, solver_name, output_spec, gzip_patterns, pIndOutputResults, pIndLogConsole, output_format)
-                for case in cases]
+            work = [(case, solver_name, output_spec, gzip_patterns, pIndOutputResults, pIndLogConsole, output_format)
+                    for case in cases]
 
-        if backend == "serial":
-            records = [_run_one(*args) for args in work]
-        elif backend == "multiprocessing":
-            import multiprocessing as mp
-            with mp.Pool(processes=n_workers) as pool:
-                records = pool.starmap(_run_one, work)
-        elif backend == "joblib":
-            try:
-                from joblib import Parallel, delayed
-            except ImportError as exc:
-                raise ImportError("backend='joblib' requires joblib (pip install joblib).") from exc
-            records = Parallel(n_jobs=n_workers)(delayed(_run_one)(*args) for args in work)
+            if backend == "serial":
+                records = [_run_one(*args) for args in work]
+            elif backend == "multiprocessing":
+                import multiprocessing as mp
+                with mp.Pool(processes=n_workers) as pool:
+                    records = pool.starmap(_run_one, work)
+            elif backend == "joblib":
+                try:
+                    from joblib import Parallel, delayed
+                except ImportError as exc:
+                    raise ImportError("backend='joblib' requires joblib (pip install joblib).") from exc
+                records = Parallel(n_jobs=n_workers)(delayed(_run_one)(*args) for args in work)
+            else:
+                raise ValueError(f"unknown backend {backend!r}; expected 'serial', 'multiprocessing', or 'joblib'.")
         else:
-            raise ValueError(f"unknown backend {backend!r}; expected 'serial', 'multiprocessing', or 'joblib'.")
-    else:
-        raise ValueError(
-            f"unknown mode {mode!r}; expected 'pre-build' (Mode A) or 'in-memory' (Mode B). "
-            "Mode C (post-build hot-swap) lives in openTEPES_ProblemSolvingResolve.resolve."
-        )
+            raise ValueError(
+                f"unknown mode {mode!r}; expected 'pre-build' (Mode A) or 'in-memory' (Mode B). "
+                "Mode C (post-build hot-swap) lives in openTEPES_ProblemSolvingResolve.resolve."
+            )
 
     if aggregate_to:
         solved = [(case, rec) for case, rec in zip(cases, records) if rec.get("status") != "error"]

--- a/tests/test_thread_cap.py
+++ b/tests/test_thread_cap.py
@@ -3,11 +3,14 @@
 The fallback is the test that matters: with nothing set, or with a value that is not a positive
 integer, ``_threads()`` must return what it always did, so existing runs do not move.
 """
+import os
+
 import psutil
 import pytest
 
 from openTEPES.openTEPES_Main import parser
 from openTEPES.openTEPES_ProblemSolvingTuning import _threads
+from openTEPES.openTEPES_Runner import _worker_thread_budget
 
 
 def _default() -> int:
@@ -45,3 +48,23 @@ def test_flag_wins_over_the_environment(monkeypatch):
     args = parser.parse_args(["--threads", "2"])
     monkeypatch.setenv("OTEPES_THREADS", str(args.threads))   # what openTEPES_Main.main() does
     assert _threads() == 2
+
+
+def test_a_parallel_sweep_splits_the_budget_and_restores_it(monkeypatch):
+    monkeypatch.delenv("OTEPES_THREADS", raising=False)
+    with _worker_thread_budget("multiprocessing", 4):
+        assert _threads() == max(1, _default() // 4)
+    assert "OTEPES_THREADS" not in os.environ
+
+
+def test_a_count_the_user_set_survives_the_sweep(monkeypatch):
+    monkeypatch.setenv("OTEPES_THREADS", "3")
+    with _worker_thread_budget("multiprocessing", 4):
+        assert _threads() == 3
+
+
+@pytest.mark.parametrize("backend,n_workers", [("serial", 1), ("serial", 4), ("multiprocessing", 1)])
+def test_one_case_at_a_time_keeps_the_default(monkeypatch, backend, n_workers):
+    monkeypatch.delenv("OTEPES_THREADS", raising=False)
+    with _worker_thread_budget(backend, n_workers):
+        assert _threads() == _default()

--- a/tests/test_thread_cap.py
+++ b/tests/test_thread_cap.py
@@ -1,0 +1,47 @@
+"""The solver thread count can be capped, and is unchanged when it is not.
+
+The fallback is the test that matters: with nothing set, or with a value that is not a positive
+integer, ``_threads()`` must return what it always did, so existing runs do not move.
+"""
+import psutil
+import pytest
+
+from openTEPES.openTEPES_Main import parser
+from openTEPES.openTEPES_ProblemSolvingTuning import _threads
+
+
+def _default() -> int:
+    return int((psutil.cpu_count(logical=True) + psutil.cpu_count(logical=False)) / 2)
+
+
+def test_default_when_nothing_is_set(monkeypatch):
+    monkeypatch.delenv("OTEPES_THREADS", raising=False)
+    assert _threads() == _default()
+
+
+def test_environment_variable_caps_the_count(monkeypatch):
+    monkeypatch.setenv("OTEPES_THREADS", "3")
+    assert _threads() == 3
+
+
+@pytest.mark.parametrize("value", ["", "junk", "0", "-2", "2.5"])
+def test_unusable_value_falls_back_to_the_default(monkeypatch, value):
+    monkeypatch.setenv("OTEPES_THREADS", value)
+    assert _threads() == _default()
+
+
+def test_flag_is_parsed():
+    assert parser.parse_args(["--threads", "4"]).threads == 4
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "junk"])
+def test_flag_rejects_a_count_below_one(value):
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--threads", value])
+
+
+def test_flag_wins_over_the_environment(monkeypatch):
+    monkeypatch.setenv("OTEPES_THREADS", "9")
+    args = parser.parse_args(["--threads", "2"])
+    monkeypatch.setenv("OTEPES_THREADS", str(args.threads))   # what openTEPES_Main.main() does
+    assert _threads() == 2


### PR DESCRIPTION
`_threads()` fixes the solver thread count at half of (logical + physical) cores, with no way to override it. That takes half of a shared machine, and it stops cases running side by side: each one claims half, so they oversubscribe and fight.

Set it with `--threads N` or `OTEPES_THREADS`. The flag writes the variable, so `_threads()` stays the one place that decides. Unset or unusable values keep the old default, so existing runs do not move. 22 lines, plus a test.

Checks on a 12-core box: default 9, unchanged; `--threads 3` and `OTEPES_THREADS=3` both give 3; the flag wins over the variable; junk and values below one fall back; `--threads 0` is rejected.

Ran three cases side by side at 4 threads each.