### PR TITLE
Release the fixed plan and reject unreachable overlays in Mode C (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## [4.18.17RC] - 2026-07-15 Unreleased in PyPI
+## [4.18.17RC] - 2026-07-16 Unreleased in PyPI
 
+- [FIXED] a Mode C sweep now re-optimises the investment plan (issue #148). The solve fixes the plan to read the duals, and resolve released that before, so a demand rise was met with unserved energy instead of new build and the cost was too high. resolve now calls unfix_for_duals first. Adds a test that the line investment moves under a demand overlay.
+- [ADDED] resolve now rejects an overlay the built model does not read live, instead of swapping it silently. A misspelt name raises, and so does a mutable Param the built model does not reference — either captured as a constant with pX[...]() or read only by a constraint that was skipped for the case. On 9n the adequacy and RES-energy constraints are skipped (no generation candidates), so pEFOR, pReserveMargin and pRESEnergy have no live effect and an overlay of them raises.
 - [FIXED] the output parity check now compares text labels correctly on pandas 3. pandas 2 turned a blank label into the text "None", but pandas 3 keeps it missing, and a missing value never equals itself, so two identical runs were reported as different.
 - [CHANGED] allow pandas 3 and refresh the pinned dependencies. openTEPES now accepts `pandas>=2.2.2,<4`, and `requirements.lock` moves to pandas 3.0.3. streamlit moves to 1.59.2 in the same step, because streamlit 1.55 and older require pandas 2 and would otherwise block the upgrade.
 - [FIXED] a blank cell in a text column now reads as NaN whichever backend the case comes from. The CSV reader gives NaN but DuckDB gives None, and limiting the NaN fill to numeric columns exposed the difference, which failed the CSV<->DuckDB round-trip tests.

--- a/openTEPES/openTEPES_ProblemSolvingDualExtraction.py
+++ b/openTEPES/openTEPES_ProblemSolvingDualExtraction.py
@@ -1,5 +1,5 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - June 03, 2026
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 16, 2026
 openTEPES.openTEPES_ProblemSolvingDualExtraction — fix-and-resolve pass that recovers shadow prices on a MIP solution.
 
 After an initial MIP solve, ``fix_for_duals()`` fixes every binary/integer variable to its optimal value and
@@ -14,11 +14,28 @@ revise the investment plan.
 
 ``NoRepetition`` controls scope: when set, every binary var across every ``(p, sc)`` is fixed; otherwise only
 the current ``(p, sc)`` block is fixed (the rest stays as it was at the end of the previous stage solve).
+
+``fix_for_duals`` records what it changed on the model, so ``unfix_for_duals`` can put it back. A Mode C
+sweep needs that: the fixed plan is right for reading duals but wrong for re-optimising.
 """
 from __future__ import annotations
 
 import pyomo.environ as pyo
 from pyomo.environ import UnitInterval
+
+# What fix_for_duals changed, so unfix_for_duals can put it back: keyed by id() because a Pyomo variable
+# builds an expression from ==, which makes it unusable as a dict key. Values are (var, prior domain) for
+# the relaxed binaries and (var, prior fixed flag) for the investments.
+_FIX_REGISTRY = "_pDualFixRelaxed"
+_INV_REGISTRY = "_pDualFixInvest"
+
+
+def _registry(OptModel, name) -> dict:
+    reg = getattr(OptModel, name, None)
+    if reg is None:
+        reg = {}
+        setattr(OptModel, name, reg)
+    return reg
 
 
 def fix_for_duals(OptModel, mTEPES, p, sc) -> int:
@@ -28,9 +45,11 @@ def fix_for_duals(OptModel, mTEPES, p, sc) -> int:
     already an LP and produced clean duals); the caller should skip the resolve pass entirely.
     """
     nUnfixedVars = 0
+    relaxed = _registry(OptModel, _FIX_REGISTRY)
     if mTEPES.NoRepetition == 1:
         for var in OptModel.component_data_objects(pyo.Var, active=True, descend_into=True):
             if not var.is_continuous() and not var.is_fixed() and var.value is not None:
+                relaxed.setdefault(id(var), (var, var.domain))
                 var.fixed  = True
                 var.domain = UnitInterval
                 nUnfixedVars += 1
@@ -38,6 +57,7 @@ def fix_for_duals(OptModel, mTEPES, p, sc) -> int:
         for var in OptModel.component_data_objects(pyo.Var, active=True, descend_into=True):
             if (not var.is_continuous() and not var.is_fixed() and var.value is not None
                     and var.index()[0] == p and var.index()[1] == sc):
+                relaxed.setdefault(id(var), (var, var.domain))
                 var.fixed  = True
                 var.domain = UnitInterval
                 nUnfixedVars += 1
@@ -45,29 +65,57 @@ def fix_for_duals(OptModel, mTEPES, p, sc) -> int:
     # Continuous investment decisions are fixed to their optimal values regardless of NoRepetition; without
     # this the LP re-solve could revisit the investment plan, which would distort the duals on the operation
     # constraints.
+    invest = _registry(OptModel, _INV_REGISTRY)
+
+    def _fix_investment(var):
+        # Record whether it was already fixed before this pass: unfix_for_duals must release only what was
+        # pinned here, and leave a decision the case itself fixed alone.
+        invest.setdefault(id(var), (var, var.fixed))
+        var.fix(var())
+
     for eb in mTEPES.eb:
         if (p, eb) in mTEPES.peb:
-            OptModel.vGenerationInvest[p, eb].fix(OptModel.vGenerationInvest[p, eb]())
+            _fix_investment(OptModel.vGenerationInvest[p, eb])
     for gd in mTEPES.gd:
         if (p, gd) in mTEPES.pgd:
-            OptModel.vGenerationRetire[p, gd].fix(OptModel.vGenerationRetire[p, gd]())
+            _fix_investment(OptModel.vGenerationRetire[p, gd])
     for ni, nf, cc in mTEPES.lc:
         if (p, ni, nf, cc) in mTEPES.plc:
-            OptModel.vNetworkInvest[p, ni, nf, cc].fix(OptModel.vNetworkInvest[p, ni, nf, cc]())
+            _fix_investment(OptModel.vNetworkInvest[p, ni, nf, cc])
     if mTEPES.pIndHydroTopology:
         for rc in mTEPES.rn:
             if (p, rc) in mTEPES.prc:
-                OptModel.vReservoirInvest[p, rc].fix(OptModel.vReservoirInvest[p, rc]())
+                _fix_investment(OptModel.vReservoirInvest[p, rc])
     if mTEPES.pIndHydrogen:
         for ni, nf, cc in mTEPES.pc:
             if (p, ni, nf, cc) in mTEPES.ppc:
-                OptModel.vH2PipeInvest[p, ni, nf, cc].fix(OptModel.vH2PipeInvest[p, ni, nf, cc]())
+                _fix_investment(OptModel.vH2PipeInvest[p, ni, nf, cc])
     if mTEPES.pIndHeat:
         for ni, nf, cc in mTEPES.hc:
             if (p, ni, nf, cc) in mTEPES.phc:
-                OptModel.vHeatPipeInvest[p, ni, nf, cc].fix(OptModel.vHeatPipeInvest[p, ni, nf, cc]())
+                _fix_investment(OptModel.vHeatPipeInvest[p, ni, nf, cc])
 
     return nUnfixedVars
+
+
+def unfix_for_duals(OptModel) -> int:
+    """Undo ``fix_for_duals``: restore the relaxed domains and release what it fixed. Returns the count.
+
+    Only what ``fix_for_duals`` changed is touched, so a decision the case itself fixed stays fixed. Safe to
+    call on a model that was never solved, where it does nothing.
+    """
+    n = 0
+    for var, prior_domain in _registry(OptModel, _FIX_REGISTRY).values():
+        var.fixed  = False
+        var.domain = prior_domain
+        n += 1
+    for var, was_fixed in _registry(OptModel, _INV_REGISTRY).values():
+        if not was_fixed:
+            var.unfix()
+            n += 1
+    _registry(OptModel, _FIX_REGISTRY).clear()
+    _registry(OptModel, _INV_REGISTRY).clear()
+    return n
 
 
 def collect_duals(OptModel, mTEPES) -> None:

--- a/openTEPES/openTEPES_ProblemSolvingResolve.py
+++ b/openTEPES/openTEPES_ProblemSolvingResolve.py
@@ -1,17 +1,50 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - June 11, 2026
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 16, 2026
 
 openTEPES.openTEPES_ProblemSolvingResolve — Mode C post-build hot-swap re-solve.
 
-Re-solve a built model once per parameter overlay without rebuilding, so a sweep reuses the
-one slow build. Only ``mutable=True`` Params hot-swap: ``pDemandElec``, ``pENSCost``,
-``pLinearVarCost``, ``pEFOR``, ``pReserveMargin``, ``pRESEnergy``. See ``resolve`` for the
-overlay format.
+Re-solve a built model once per parameter overlay without rebuilding, so a sweep reuses the one slow build.
+A swap reaches the model only for a ``mutable=True`` Param the built model reads live; ``resolve`` rejects
+an overlay it cannot see. A Param is not read live when a constraint captured its value as a constant with
+``pX[...]()``, or when the constraints that reference it were skipped for the case (e.g. the adequacy
+reserve margin on a case with no generation candidates). A swap is also inexact for a Param with a
+build-derived dependent: ``pDemandElec`` sets the immutable peak and the commitment boundary, which a swap
+does not update. See ``resolve`` for the overlay format.
 """
 from __future__ import annotations
 
-from pyomo.environ import SolverFactory
+from pyomo.environ import SolverFactory, Constraint, Objective
 from pyomo.opt import TerminationCondition
+from pyomo.core.expr import identify_mutable_parameters
+
+try:
+    from .openTEPES_ProblemSolvingDualExtraction import unfix_for_duals
+except ImportError:  # direct run: no parent package
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from openTEPES_ProblemSolvingDualExtraction import unfix_for_duals
+
+
+def _live_mutable_params(OptModel) -> set[str]:
+    """Names of the mutable Params the active constraints and objective actually read live.
+
+    A constraint that captures a Param with ``pX[...]()`` freezes its value at build time, so swapping the
+    Param later does nothing there. Only a Param referenced without the call stays live. This returns the set
+    that a swap can still reach, so resolve can reject an overlay that would silently do nothing.
+    """
+    live = set()
+    for obj in OptModel.component_data_objects(Objective, active=True):
+        for par in identify_mutable_parameters(obj.expr):
+            live.add(par.parent_component().name)
+    # A constraint keeps its right-hand side in lower / upper, not body: an equality sum(...) == pDemandElec
+    # holds pDemandElec in the bound. Walk all three or a Param used only as a bound is missed.
+    for con in OptModel.component_data_objects(Constraint, active=True):
+        for expr in (con.body, con.lower, con.upper):
+            if expr is not None:
+                for par in identify_mutable_parameters(expr):
+                    live.add(par.parent_component().name)
+    return live
 
 
 def overlay_scaled(OptModel, param_name: str, factor: float) -> dict:
@@ -31,14 +64,32 @@ def resolve(OptModel, SolverName: str, overlays, *, restore: bool = True, tee: b
     ``{}`` re-solves the baseline. ``restore`` (default) restores the baseline at the end.
     ``SolverName`` must be non-persistent. Returns one dict per overlay with the termination
     condition and total system cost (None if not optimal).
+
+    Releases the investment and commitment decisions that the solve fixed to read the duals, so each
+    overlay re-optimises them. Decisions the case itself fixed stay fixed.
     """
     overlays = list(overlays)
 
-    # Snapshot the baseline of every touched Param: used to reset before each overlay (so
-    # overlays are independent, not cumulative) and for the optional restore at the end.
+    # Solving fixes the investment plan and the commitment to read the duals, so a model that has been solved
+    # would answer a demand rise with unserved energy instead of new capacity, and report too high a cost
+    # without saying anything. Release those decisions first; a model that was never solved is unaffected.
+    unfix_for_duals(OptModel)
+
+    # Reject an overlay the re-solve cannot see, so it does not swap silently and return an unchanged cost as
+    # if it had worked. A Param is unseen when the name is wrong, a constraint captured its value as a
+    # constant, or the constraints that use it were skipped for this case.
     touched = set()
     for ov in overlays:
         touched.update(ov.keys())
+    live = _live_mutable_params(OptModel)
+    inert = sorted(name for name in touched if name not in live)
+    if inert:
+        raise ValueError(
+            f"resolve() cannot apply these overlays; the built model does not read them live: {', '.join(inert)}."
+        )
+
+    # Snapshot the baseline of every touched Param: used to reset before each overlay (so
+    # overlays are independent, not cumulative) and for the optional restore at the end.
     baseline = {name: getattr(OptModel, name).extract_values() for name in touched}
 
     Solver = SolverFactory(SolverName)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -372,6 +372,39 @@ def test_mode_c_resolve_demand_hot_swap(case_7d_system):
     assert restored[0]["total_cost_meur"] == pytest.approx(base, rel=1e-7)
 
 
+@pytest.mark.solve
+@pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
+def test_mode_c_resolve_reoptimises_investment(case_7d_system):
+    """A demand rise in a Mode C sweep must move the investment plan, not just add unserved energy.
+
+    The solve fixes the plan to read the duals; resolve releases it first. Without that release the line
+    investment stays at its baseline value and the reported cost is too high (issue #148).
+    """
+    mTEPES = openTEPES_run(**case_7d_system)
+    line = next(iter(mTEPES.vNetworkInvest))
+    base_invest = mTEPES.vNetworkInvest[line]()
+
+    resolve(mTEPES, "highs", [overlay_scaled(mTEPES, "pDemandElec", 1.5)], restore=False)
+    assert mTEPES.vNetworkInvest[line]() > base_invest + 1e-3
+    assert not any(mTEPES.vNetworkInvest[i].fixed for i in mTEPES.vNetworkInvest)
+
+
+@pytest.mark.solve
+@pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
+def test_mode_c_resolve_rejects_unreachable_overlay(case_7d_system):
+    """resolve refuses an overlay the built model does not read live, instead of swapping it silently.
+
+    ``pEFOR`` is mutable but 9n has no generation candidates, so the adequacy constraint that reads it is
+    skipped and no live constraint references it; a misspelt name is unreachable too. Both must raise rather
+    than return an unchanged cost.
+    """
+    mTEPES = openTEPES_run(**case_7d_system)
+    with pytest.raises(ValueError, match="does not read them live"):
+        resolve(mTEPES, "highs", [{"pEFOR": mTEPES.pEFOR.extract_values()}])
+    with pytest.raises(ValueError, match="does not read them live"):
+        resolve(mTEPES, "highs", [{"pDemandElecc": {}}])
+
+
 # === Binary (MILP) investment test ===
 #
 # Every other case here solves the investment variables as a continuous relaxation, so no other test


### PR DESCRIPTION
Fixes #148. Figures: 9n, 7-day, gurobi.

## Problem

`openTEPES_run` returns a solved model whose investment plan is fixed for dual recovery. `resolve` re-solved
it fixed, so a demand increase drew unserved energy rather than capacity (+8.98 %).

## Method

- `resolve` calls a new `unfix_for_duals`, reverting only what `fix_for_duals` recorded: relaxed binaries
  regain their domain, and only investments it pinned are released.
- `resolve` rejects an overlay the built model does not read live, rather than swapping it and returning an
  unchanged cost.

## Results

The candidate line re-optimises (0.4631 → 0.8815) and the null overlay reproduces the baseline. On 9n the
adequacy and RES-energy constraints are skipped (no generation candidates), so `pEFOR`, `pReserveMargin` and
`pRESEnergy` are unreachable and their overlays now raise. A sweep is exact only for a parameter read live
throughout with no build-derived dependent; `pDemandElec` also sets the immutable peak and the commitment
boundary. Two tests added.

## Open

- Reaching `pEFOR` / `pReserveMargin` / `pRESEnergy` is not a matter of dropping the `()`: the bodies read
  them live already. Building adequacy without candidates yields `capacity >= peak x margin` on the fixed
  system, which may be infeasible.
- Demand-sweep boundary: document as approximate, cold-start per overlay, or route through the stage loop.
