### PR TITLE
CI: exercise the pandas 2 floor and pin highspy (#150, #151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,50 @@ jobs:
         run: |
           pytest -vv -m solve --timeout=1800 tests/
 
+  # Pandas 2 floor: the lock pins pandas 3, but pyproject still supports pandas 2
+  # (>=2.2.2,<4), so nothing would exercise the older end of the range. This job
+  # installs the lock, pins pandas back to the 2.x floor, and runs the unit and
+  # solve tests. One combo is enough: the variable is the pandas version, not the
+  # platform.
+  pandas2:
+    name: pandas 2 floor (unit + solve) - ubuntu-latest / py3.12
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Conda (Miniforge) + Python 3.12
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          auto-update-conda: true
+          activate-environment: ci
+          python-version: "3.12"
+          channels: conda-forge,defaults
+          channel-priority: strict
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: requirements.lock
+
+      - name: Install dependencies, then pin pandas to the 2.x floor
+        shell: bash -l {0}
+        run: |
+          conda install -y -c conda-forge flake8 pytest pytest-timeout
+          uv pip install --system -r requirements.lock
+          uv pip install --system highspy
+          pip install -e .
+          uv pip install --system "pandas>=2.2.2,<3"
+
+      - name: Run unit and solve tests
+        shell: bash -l {0}
+        run: |
+          pytest -vv -m "not solve" tests/
+          pytest -vv -m solve --timeout=1800 tests/
+
   # Docs tier: build the Read the Docs site with warnings treated as errors, so
   # a broken cross-reference, a missing toctree entry, or a bad directive fails
   # the PR. No solver or model dependency, so it runs once on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           conda install -y -c conda-forge flake8 pytest pytest-timeout
           uv pip install --system -r requirements.lock
-          uv pip install --system highspy
+          uv pip install --system "highspy==1.15.1"
           pip install -e .
 
       - name: Run solve tests (per-test timeout guards a stuck solver)
@@ -140,7 +140,7 @@ jobs:
         run: |
           conda install -y -c conda-forge flake8 pytest pytest-timeout
           uv pip install --system -r requirements.lock
-          uv pip install --system highspy
+          uv pip install --system "highspy==1.15.1"
           pip install -e .
           uv pip install --system "pandas>=2.2.2,<3"
 

--- a/.github/workflows/colab-compatibility.yml
+++ b/.github/workflows/colab-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install pytest highspy
+        pip install pytest "highspy==1.15.1"
 
     - name: Run tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [4.18.17RC] - 2026-07-17 Unreleased in PyPI
 
-- [ADDED] a CI job that runs the unit and solve tests with pandas pinned to the 2.x floor (issue #150). The lock pins pandas 3, so without this nothing exercised the older end of the supported `pandas>=2.2.2,<4` range.
+- [ADDED] a CI job that runs the tests with pandas pinned to the 2.x floor, since the lock pins pandas 3 and nothing else exercised the older end of `pandas>=2.2.2,<4` (issue #150).
+- [CHANGED] pin `highspy==1.15.1` in the CI and Colab workflows, so a solve result is reproducible from the lock and a HiGHS release cannot fail an unrelated PR (issue #151).
 
 - [FIXED] a Mode C sweep now re-optimises the investment plan (issue #148). The solve fixes the plan to read the duals, and resolve released that before, so a demand rise was met with unserved energy instead of new build and the cost was too high. resolve now calls unfix_for_duals first. Adds a test that the line investment moves under a demand overlay.
 - [ADDED] resolve now rejects an overlay the built model does not read live, instead of swapping it silently. A misspelt name raises, and so does a mutable Param the built model does not reference — either captured as a constant with pX[...]() or read only by a constraint that was skipped for the case. On 9n the adequacy and RES-energy constraints are skipped (no generation candidates), so pEFOR, pReserveMargin and pRESEnergy have no live effect and an overlay of them raises.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## [4.18.17RC] - 2026-07-16 Unreleased in PyPI
+## [4.18.17RC] - 2026-07-17 Unreleased in PyPI
+
+- [ADDED] a CI job that runs the unit and solve tests with pandas pinned to the 2.x floor (issue #150). The lock pins pandas 3, so without this nothing exercised the older end of the supported `pandas>=2.2.2,<4` range.
 
 - [FIXED] a Mode C sweep now re-optimises the investment plan (issue #148). The solve fixes the plan to read the duals, and resolve released that before, so a demand rise was met with unserved energy instead of new build and the cost was too high. resolve now calls unfix_for_duals first. Adds a test that the line investment moves under a demand overlay.
 - [ADDED] resolve now rejects an overlay the built model does not read live, instead of swapping it silently. A misspelt name raises, and so does a mutable Param the built model does not reference — either captured as a constant with pX[...]() or read only by a constraint that was skipped for the case. On 9n the adequacy and RES-energy constraints are skipped (no generation candidates), so pEFOR, pReserveMargin and pRESEnergy have no live effect and an overlay of them raises.


### PR DESCRIPTION
Closes #150 and #151. CI-only.

- **#150** — the lock pins pandas 3, so nothing exercised the older end of `pandas>=2.2.2,<4`. A `pandas2` job installs the lock, pins pandas to the 2.x floor, and runs unit + solve on ubuntu / py3.12.
- **#151** — the solve tests run on HiGHS, installed unpinned and absent from the lock. Pin `highspy==1.15.1` in the CI and Colab workflows.

Verified: the `pandas2` stack (pandas 2.3.3, numpy 2.4.6, streamlit 1.59.2, pyomo 6.10.1, highspy 1.15.1) passes the unit and Mode C solve tests locally; the CI job is green.
