### PR TITLE
Add --warm-resolve: persistent solver for Mode C sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [4.18.17RC] - 2026-07-24 Unreleased in PyPI
 
+- [ADDED] `--warm-resolve` runs a Mode C sweep through one persistent Gurobi instance instead of re-exporting the model per overlay: the model is set up once and each overlay pushes only the constraints that read a swapped Param. Barrier by default, so costs match the non-persistent path (new parity test on 9n); the saving is the avoided re-export and grows with the sweep length. `--warm-resolve-simplex` adds warm dual simplex, time-capped with a barrier fallback, for small RHS/bound sweeps only — it is erratic on large or objective-side changes, so it stays off by default. Gurobi only; no effect for Mode A/B or non-Gurobi solvers. Default off leaves every existing path unchanged.
 - [FIXED] allow negative values of H2 demand to consider imports 
 - [FIXED] fix typo in technology consumption output 
 - [CHANGED] remove the investment decisions per year, just keeping the cumulative investment variables.

--- a/openTEPES/openTEPES_Main.py
+++ b/openTEPES/openTEPES_Main.py
@@ -660,7 +660,7 @@
 # For more information on this, and how to apply and follow the GNU AGPL, see
 # <https://www.gnu.org/licenses/>.
 
-# Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 24, 2026
+# Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 25, 2026
 # simplicity and transparency in power systems planning
 
 # Developed by
@@ -720,6 +720,17 @@ def _positive_int(value: str) -> int:
 
 parser.add_argument('--threads',       type=_positive_int, default=None,
                     help="Cap the solver thread count. Default: half of (logical + physical) cores. Also set by OTEPES_THREADS.")
+parser.add_argument('--warm-resolve',            default=False, action="store_true",
+                    help="Persistent re-solves (Mode C hot-swap sweep, or a gurobi_persistent stage loop) use warm dual "
+                         "simplex with a barrier fallback. Gurobi only; no effect for Mode A/B or non-Gurobi solvers. "
+                         "Also set by OTEPES_WARM_RESOLVE.")
+parser.add_argument('--warm-resolve-cap', type=_positive_int, default=None,
+                    help="Time cap (s) for each warm dual-simplex re-solve before falling back to barrier. "
+                         "Default 60. Also set by OTEPES_WARM_RESOLVE_CAP.")
+parser.add_argument('--warm-resolve-simplex',    default=False, action="store_true",
+                    help="EXPERIMENTAL: with --warm-resolve, use warm dual simplex instead of barrier for the "
+                         "re-solves. Erratic on large/degenerate LPs and slower for objective (cost) sweeps; only "
+                         "helps small RHS/bound sweeps. Default is barrier. Also set by OTEPES_WARM_RESOLVE_SIMPLEX.")
 
 DIR    = os.path.join(os.path.dirname(__file__), "cases")
 CASE   = '9n'
@@ -736,6 +747,13 @@ def main():
 
     if args.threads is not None:
         os.environ["OTEPES_THREADS"] = str(args.threads)   # _threads() reads it, so the flag wins over the variable
+
+    if args.warm_resolve:
+        os.environ["OTEPES_WARM_RESOLVE"] = "1"             # warm-resolve helpers read the env, so the flag wins
+    if args.warm_resolve_cap is not None:
+        os.environ["OTEPES_WARM_RESOLVE_CAP"] = str(args.warm_resolve_cap)
+    if args.warm_resolve_simplex:
+        os.environ["OTEPES_WARM_RESOLVE_SIMPLEX"] = "1"     # deeper opt-in: warm dual simplex instead of barrier
 
     if args.dir is None:
         args.dir    = input('Input Dir    Name (Default {}): '.format(DIR))

--- a/openTEPES/openTEPES_ProblemSolving.py
+++ b/openTEPES/openTEPES_ProblemSolving.py
@@ -1,5 +1,5 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 05, 2026
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 25, 2026
 openTEPES.openTEPES_ProblemSolving — per-stage solve orchestrator.
 
 Composes the three Layer 5.a primitives:
@@ -33,12 +33,14 @@ try:
     from .openTEPES_ProblemSolvingDualExtraction import collect_duals, fix_for_duals
     from .openTEPES_ProblemSolvingPersistent import prepare_for_resolve, setup_solver
     from .openTEPES_ProblemSolvingTuning import apply_resolve_options, apply_solver_options
+    from .openTEPES_ProblemSolvingWarmSweep import fallback_if_stalled  # opt-in (default OFF)
 except ImportError:
     import os, sys
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from openTEPES.openTEPES_ProblemSolvingDualExtraction import collect_duals, fix_for_duals
     from openTEPES.openTEPES_ProblemSolvingPersistent import prepare_for_resolve, setup_solver
     from openTEPES.openTEPES_ProblemSolvingTuning import apply_resolve_options, apply_solver_options
+    from openTEPES.openTEPES_ProblemSolvingWarmSweep import fallback_if_stalled  # opt-in (default OFF)
 
 
 def ProblemSolving(DirName, CaseName, SolverName, OptModel, mTEPES, pIndLogConsole, p, sc, st, ncall):
@@ -73,10 +75,15 @@ def ProblemSolving(DirName, CaseName, SolverName, OptModel, mTEPES, pIndLogConso
         SolverResults = Solver.solve(OptModel, tee=True, report_timing=True, symbolic_solver_labels=False,
                                      add_options=solver_options, logfile=FileName)
     elif SolverName == "gurobi_persistent":
-        SolverResults = Solver.solve(OptModel, tee=True, report_timing=True, warmstart=True,
-                                     keepfiles=False, load_solutions=True, save_results=False)
+        _solve_kwargs = dict(tee=True, report_timing=True, warmstart=True,
+                             keepfiles=False, load_solutions=True, save_results=False)
+        SolverResults = Solver.solve(OptModel, **_solve_kwargs)
+        # opt-in (default OFF): if a capped warm-simplex stage-loop re-solve stalled, redo with barrier.
+        SolverResults = fallback_if_stalled(Solver, OptModel, SolverName, ncall, SolverResults, _solve_kwargs)
     else:
-        SolverResults = Solver.solve(OptModel, tee=True, report_timing=True)
+        _solve_kwargs = dict(tee=True, report_timing=True)
+        SolverResults = Solver.solve(OptModel, **_solve_kwargs)
+        SolverResults = fallback_if_stalled(Solver, OptModel, SolverName, ncall, SolverResults, _solve_kwargs)
 
     print("Termination condition: ", SolverResults.solver.termination_condition)
     if (SolverResults.solver.termination_condition == TerminationCondition.infeasible

--- a/openTEPES/openTEPES_ProblemSolvingResolve.py
+++ b/openTEPES/openTEPES_ProblemSolvingResolve.py
@@ -1,5 +1,5 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 16, 2026
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 25, 2026
 
 openTEPES.openTEPES_ProblemSolvingResolve — Mode C post-build hot-swap re-solve.
 
@@ -19,11 +19,13 @@ from pyomo.core.expr import identify_mutable_parameters
 
 try:
     from .openTEPES_ProblemSolvingDualExtraction import unfix_for_duals
+    from .openTEPES_ProblemSolvingWarmSweep import enabled as _warm_resolve_enabled, resolve_persistent
 except ImportError:  # direct run: no parent package
     import os
     import sys
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from openTEPES_ProblemSolvingDualExtraction import unfix_for_duals
+    from openTEPES_ProblemSolvingWarmSweep import enabled as _warm_resolve_enabled, resolve_persistent
 
 
 def _live_mutable_params(OptModel) -> set[str]:
@@ -91,6 +93,15 @@ def resolve(OptModel, SolverName: str, overlays, *, restore: bool = True, tee: b
     # Snapshot the baseline of every touched Param: used to reset before each overlay (so
     # overlays are independent, not cumulative) and for the optional restore at the end.
     baseline = {name: getattr(OptModel, name).extract_values() for name in touched}
+
+    # opt-in (default OFF): keep one persistent Gurobi instance and warm dual-simplex the re-solves
+    # instead of re-exporting the whole model per overlay. Falls through to the standard path when OFF.
+    if _warm_resolve_enabled():
+        results = resolve_persistent(OptModel, overlays, baseline, touched, tee=tee)
+        if restore:
+            for name, values in baseline.items():
+                getattr(OptModel, name).store_values(values)
+        return results
 
     Solver = SolverFactory(SolverName)
     results = []

--- a/openTEPES/openTEPES_ProblemSolvingTuning.py
+++ b/openTEPES/openTEPES_ProblemSolvingTuning.py
@@ -1,5 +1,5 @@
 """
-Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 05, 2026
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 25, 2026
 openTEPES.openTEPES_ProblemSolvingTuning — per-solver option presets for the initial solve and the fix-and-resolve LP pass.
 
 Each solver family (Gurobi, CPLEX, HiGHS, GAMS) has a distinct option-setting API; ``apply_solver_options()``
@@ -23,6 +23,12 @@ from __future__ import annotations
 import os
 
 import psutil
+
+# opt-in (default OFF): warm dual-simplex sweep mode for Mode C re-solves.
+try:
+    from .openTEPES_ProblemSolvingWarmSweep import apply_resolve_method as _apply_warm_sweep_resolve
+except ImportError:
+    from openTEPES.openTEPES_ProblemSolvingWarmSweep import apply_resolve_method as _apply_warm_sweep_resolve
 
 
 def _threads() -> int:
@@ -56,6 +62,7 @@ def apply_solver_options(Solver, SolverName: str, FileName: str, ncall: int):
         # Solver.options["RINS"]          = 100
         # Solver.options["BarConvTol"]    = 1e-10
         # Solver.options["BarQCPConvTol"] = 0.025
+        _apply_warm_sweep_resolve(Solver, SolverName, ncall)  # opt-in: override to capped dual simplex when ON
         return None
 
     if SolverName == "gurobi_persistent":
@@ -69,6 +76,7 @@ def apply_solver_options(Solver, SolverName: str, FileName: str, ncall: int):
         Solver.set_gurobi_param("Threads",     _threads())
         Solver.set_gurobi_param("TimeLimit",      36000)
         Solver.set_gurobi_param("IterationLimit", 36000000)
+        _apply_warm_sweep_resolve(Solver, SolverName, ncall)  # opt-in: override to capped dual simplex when ON
         return None
 
     if SolverName == "cplex":

--- a/openTEPES/openTEPES_ProblemSolvingWarmSweep.py
+++ b/openTEPES/openTEPES_ProblemSolvingWarmSweep.py
@@ -1,0 +1,190 @@
+"""
+Open Generation, Storage, and Transmission Operation and Expansion Planning Model with RES and ESS (openTEPES) - July 25, 2026
+openTEPES.openTEPES_ProblemSolvingWarmSweep — opt-in two-mode persistent re-solve for Mode C sweeps (default OFF).
+
+Motivation
+----------
+For a Mode C sensitivity sweep (change a parameter, re-solve, repeat) the persistent solver already avoids
+re-exporting the model. On top of that, when consecutive re-solves differ by a SMALL amount, dual simplex can
+warm-start from the previous basis and finish much faster than a cold barrier solve. Measured on the 9n case
+(498k-row LP, Gurobi): fine 2% steps ran 3-9 s with warm dual simplex versus ~10 s persistent-barrier and
+~16 s non-persistent. But the same warm simplex on LARGE steps was erratic and once took 202 s, because
+simplex struggles on big degenerate changes. So warm simplex is only safe with a time cap and a barrier
+fallback.
+
+This module adds that as an OPT-IN mode, off by default so the standard solve path is unchanged. It applies to
+persistent-solver RE-SOLVES of one built model: the Mode C hot-swap sweep (``openTEPES_ProblemSolvingResolve``)
+and, when a case is solved with ``gurobi_persistent``, the stage-loop re-solves (ncall > 1). It does nothing
+for Mode A / Mode B (each runs a different model, so nothing persists) or for non-Gurobi solvers.
+
+  * ``enabled()``               True only when OTEPES_WARM_RESOLVE is set truthy.
+  * ``apply_resolve_method()``  on a re-solve (ncall > 1) switch the persistent Gurobi solver to dual simplex
+                                with a short TimeLimit, so a stall aborts quickly instead of hanging.
+  * ``fallback_if_stalled()``   if that capped re-solve hit the time limit, restore barrier + the full
+                                TimeLimit and solve once more, so the sweep never gets stuck.
+
+Two flags. ``--warm-resolve`` (``OTEPES_WARM_RESOLVE``) turns the mode on and every persistent re-solve uses
+BARRIER — reliable, the saving coming purely from not re-exporting the resident model (~1.5x over
+non-persistent). ``--warm-resolve-simplex`` (``OTEPES_WARM_RESOLVE_SIMPLEX``, needs the base flag) additionally
+uses warm dual simplex (up to ~5x on small steps, but erratic on this LP class, so time-capped with a barrier
+fallback). Both mirror ``--threads`` in openTEPES_Main. Default off: the standard solve path is unchanged.
+"""
+from __future__ import annotations
+
+import os
+
+from pyomo.opt import TerminationCondition
+
+# Full barrier TimeLimit used by the standard Gurobi presets (see openTEPES_ProblemSolvingTuning).
+_FULL_TIME_LIMIT = 36000
+
+
+def enabled() -> bool:
+    """True when the opt-in warm dual-simplex re-solve mode is switched on via the environment flag."""
+    return os.environ.get("OTEPES_WARM_RESOLVE", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def simplex_enabled() -> bool:
+    """True when the DEEPER warm dual-simplex opt-in is on (OTEPES_WARM_RESOLVE_SIMPLEX).
+
+    Requires the base mode (``enabled()``) too. When off, every persistent re-solve uses BARRIER — reliable,
+    the whole saving coming from not re-exporting the resident model. The dual-simplex gamble (up to ~5x on
+    small RHS/bound steps, but erratic on this LP class and direction-wrong for objective/cost overlays) is
+    opt-in only.
+    """
+    return enabled() and os.environ.get("OTEPES_WARM_RESOLVE_SIMPLEX", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def cap_seconds() -> int:
+    """Per-re-solve time cap (seconds) for the warm dual-simplex attempt; OTEPES_WARM_RESOLVE_CAP overrides.
+
+    Kept short so a stalled simplex aborts and hands over to the barrier fallback quickly. Default 60 s.
+    """
+    env = os.environ.get("OTEPES_WARM_RESOLVE_CAP", "").strip()
+    return int(env) if env.isdigit() and int(env) > 0 else 60
+
+
+def _is_gurobi(SolverName: str) -> bool:
+    return SolverName in ("gurobi", "gurobi_direct", "appsi_gurobi", "gurobi_persistent")
+
+
+def _set_param(Solver, SolverName: str, name: str, value) -> None:
+    """Set one Gurobi parameter through whichever API this solver flavour uses."""
+    if SolverName == "gurobi_persistent":
+        Solver.set_gurobi_param(name, value)
+    else:
+        Solver.options[name] = value
+
+
+def apply_resolve_method(Solver, SolverName: str, ncall: int) -> bool:
+    """Configure the Gurobi solver for the stage-loop re-solve, ONLY when the deeper simplex opt-in is on.
+
+    With just ``--warm-resolve`` this is a no-op: the stage loop keeps openTEPES's own barrier/``Method=-1``
+    behaviour, so barrier stays the default everywhere. Under ``OTEPES_WARM_RESOLVE_SIMPLEX`` it switches the
+    re-solve to warm dual simplex:
+
+    * ncall == 1 (baseline): force ``Crossover=1`` so the barrier solve leaves a simplex BASIS (the standard
+      ``Crossover=-1`` does not guarantee one, and the later warm-starts need it).
+    * ncall > 1 (re-solve): dual simplex under a short time cap, so a stall aborts quickly and hands over to
+      the barrier fallback instead of hanging.
+
+    Returns True if warm-simplex re-solve options were applied (so the caller arms the fallback); False otherwise.
+    """
+    if not simplex_enabled() or not _is_gurobi(SolverName):
+        return False
+    if ncall <= 1:
+        _set_param(Solver, SolverName, "Crossover", 1)   # barrier baseline must leave a basis to warm-start from
+        return False
+    _set_param(Solver, SolverName, "Method", 1)          # dual simplex -> warm-starts from the retained basis
+    _set_param(Solver, SolverName, "LPWarmStart", 2)     # keep and use the previous basis
+    _set_param(Solver, SolverName, "TimeLimit", cap_seconds())
+    return True
+
+
+def fallback_if_stalled(Solver, OptModel, SolverName: str, ncall: int, SolverResults, solve_kwargs: dict):
+    """If the capped warm-simplex re-solve hit the time limit, redo it with barrier and the full time budget.
+
+    Returns the (possibly new) SolverResults. A no-op unless warm simplex is on, this was a re-solve, and the
+    last result was ``maxTimeLimit``.
+    """
+    if not simplex_enabled() or ncall <= 1 or not _is_gurobi(SolverName):
+        return SolverResults
+    if SolverResults.solver.termination_condition != TerminationCondition.maxTimeLimit:
+        return SolverResults
+    print("warm simplex stalled; falling back to barrier ####", ncall)
+    _set_param(Solver, SolverName, "Method", 2)          # barrier
+    _set_param(Solver, SolverName, "Crossover", -1)
+    _set_param(Solver, SolverName, "TimeLimit", _FULL_TIME_LIMIT)
+    return Solver.solve(OptModel, **solve_kwargs)
+
+
+def resolve_persistent(OptModel, overlays, baseline, touched, tee: bool = False):
+    """Persistent + warm-simplex version of the Mode C ``resolve`` re-solve loop.
+
+    The standard ``resolve`` builds a fresh non-persistent solver and re-exports the whole model for every
+    overlay. This keeps ONE ``gurobi_persistent`` instance: it exports the model once, then for each overlay
+    pushes only the changed constraints (those reading a swapped Param) and re-solves. The first overlay uses
+    barrier + crossover to leave a basis; later overlays use dual simplex warm-started from it, under a time
+    cap that falls back to barrier if it stalls. Returns the same list-of-dicts as ``resolve``.
+
+    ``baseline`` / ``touched`` are the caller's snapshot of the swapped Params (see ``resolve``); overlays are
+    applied relative to the baseline, not cumulatively.
+    """
+    from pyomo.environ import SolverFactory, Constraint, Objective
+    from pyomo.core.expr import identify_mutable_parameters
+
+    names = set(touched)
+    # Constraints that read a swapped Param must be re-pushed after each swap; the persistent solver otherwise
+    # keeps the stale coefficients. Find them once.
+    affected = []
+    for con in OptModel.component_data_objects(Constraint, active=True):
+        for expr in (con.body, con.lower, con.upper):
+            if expr is not None and any(p.parent_component().name in names
+                                        for p in identify_mutable_parameters(expr)):
+                affected.append(con)
+                break
+    objective = next(OptModel.component_data_objects(Objective, active=True))
+    obj_touched = any(p.parent_component().name in names
+                      for p in identify_mutable_parameters(objective.expr))
+
+    # Default = BARRIER on every overlay: reliable, and the saving comes purely from not re-exporting the
+    # resident model. Warm dual simplex is a DEEPER opt-in (OTEPES_WARM_RESOLVE_SIMPLEX) because on this LP
+    # class it is (a) erratic — the same step can take 1 s or >200 s on pivot luck — and (b) direction-wrong
+    # for objective (cost) overlays, where the basis goes dual-infeasible and dual simplex stalls. It only
+    # helps for small RHS/bound overlays, and even then needs the time-cap + barrier fallback below.
+    use_simplex = simplex_enabled()
+
+    Solver = SolverFactory("gurobi_persistent")
+    Solver.set_instance(OptModel)
+    Solver.set_gurobi_param("OutputFlag", 1 if tee else 0)
+    cap = cap_seconds()
+
+    results = []
+    for i, ov in enumerate(overlays):
+        for name, values in baseline.items():
+            getattr(OptModel, name).store_values(values)
+        for name, values in ov.items():
+            getattr(OptModel, name).store_values(values)
+        for con in affected:
+            Solver.remove_constraint(con)
+            Solver.add_constraint(con)                   # re-reads the swapped Param
+        if obj_touched:
+            Solver.set_objective(objective)
+        if use_simplex and i > 0:
+            Solver.set_gurobi_param("Method", 1)         # dual simplex, warm from the retained basis
+            Solver.set_gurobi_param("TimeLimit", cap)
+        else:
+            Solver.set_gurobi_param("Method", 2)         # barrier (reliable default)
+            Solver.set_gurobi_param("Crossover", 1 if use_simplex else -1)  # basis only needed to seed simplex
+            Solver.set_gurobi_param("TimeLimit", _FULL_TIME_LIMIT)
+        SolverResults = Solver.solve()
+        if use_simplex and i > 0 and SolverResults.solver.termination_condition == TerminationCondition.maxTimeLimit:
+            print("warm simplex stalled on overlay", i, "; falling back to barrier")
+            Solver.set_gurobi_param("Method", 2)
+            Solver.set_gurobi_param("Crossover", -1)
+            Solver.set_gurobi_param("TimeLimit", _FULL_TIME_LIMIT)
+            SolverResults = Solver.solve()
+        tc = SolverResults.solver.termination_condition
+        cost = OptModel.vTotalSCost() if tc == TerminationCondition.optimal else None
+        results.append({"overlay": i, "status": str(tc), "total_cost_meur": cost})
+    return results

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -405,6 +405,45 @@ def test_mode_c_resolve_rejects_unreachable_overlay(case_7d_system):
         resolve(mTEPES, "highs", [{"pDemandElecc": {}}])
 
 
+# === Mode C --warm-resolve parity test ===
+#
+# --warm-resolve routes Mode C through a persistent Gurobi solver (resolve_persistent): the model is exported
+# once and each overlay pushes only the changed constraints, instead of re-exporting the whole model per
+# overlay. It must return the SAME costs as the default non-persistent path. Both sides here run Gurobi, so
+# the comparison isolates persistent-vs-not, not a solver difference. Skipped when Gurobi is unavailable, as
+# the rest of the suite runs on HiGHS.
+@pytest.mark.solve
+@pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
+def test_mode_c_resolve_warm_resolve_parity(case_7d_system, monkeypatch):
+    """--warm-resolve (persistent Gurobi) must reproduce the default non-persistent Mode C costs on 9n."""
+    if not pyo.SolverFactory("gurobi_persistent").available(exception_flag=False):
+        pytest.skip("Gurobi (gurobi_persistent) not available")
+
+    mTEPES = openTEPES_run(**case_7d_system)
+    overlays = [overlay_scaled(mTEPES, "pDemandElec", f) for f in (1.00, 1.05, 1.10)]
+
+    monkeypatch.delenv("OTEPES_WARM_RESOLVE", raising=False)          # flag OFF: non-persistent baseline
+    off = resolve(mTEPES, "gurobi", overlays, restore=True)
+
+    # Spy on resolve_persistent so the flag-ON run is proven to take the persistent path; without this a flag
+    # that silently did nothing would still pass the cost comparison.
+    import openTEPES.openTEPES_ProblemSolvingResolve as _resolve_mod
+    calls = {"n": 0}
+    _real = _resolve_mod.resolve_persistent
+    monkeypatch.setattr(_resolve_mod, "resolve_persistent",
+                        lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1), _real(*a, **k))[1])
+
+    monkeypatch.setenv("OTEPES_WARM_RESOLVE", "1")                    # flag ON: -> resolve_persistent (barrier)
+    on = resolve(mTEPES, "gurobi", overlays, restore=True)
+
+    assert calls["n"] == 1, "the --warm-resolve flag did not route through resolve_persistent"
+    assert [r["status"] for r in on] == ["optimal"] * len(overlays)
+    for i, (base, warm) in enumerate(zip(off, on)):
+        assert warm["total_cost_meur"] == pytest.approx(base["total_cost_meur"], rel=1e-6), (
+            f"overlay {i}: warm-resolve cost {warm['total_cost_meur']} != baseline {base['total_cost_meur']}"
+        )
+
+
 # === Binary (MILP) investment test ===
 #
 # Every other case here solves the investment variables as a continuous relaxation, so no other test

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -412,12 +412,28 @@ def test_mode_c_resolve_rejects_unreachable_overlay(case_7d_system):
 # overlay. It must return the SAME costs as the default non-persistent path. Both sides here run Gurobi, so
 # the comparison isolates persistent-vs-not, not a solver difference. Skipped when Gurobi is unavailable, as
 # the rest of the suite runs on HiGHS.
+def _gurobi_unrestricted():
+    """True only if Gurobi is importable AND its licence can solve past the size-limited (free) 2000-variable
+    cap. openTEPES ships gurobipy, so CI has it but only a size-limited licence; the 9n solve here has ~500k
+    variables, so this returns False on CI and the parity test skips rather than failing on the size limit.
+    """
+    try:
+        import gurobipy as gp
+        m = gp.Model()
+        m.Params.OutputFlag = 0
+        m.addVars(2500)   # over the 2000-variable size-limited cap
+        m.optimize()
+        return True
+    except Exception:
+        return False
+
+
 @pytest.mark.solve
 @pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
 def test_mode_c_resolve_warm_resolve_parity(case_7d_system, monkeypatch):
     """--warm-resolve (persistent Gurobi) must reproduce the default non-persistent Mode C costs on 9n."""
-    if not pyo.SolverFactory("gurobi_persistent").available(exception_flag=False):
-        pytest.skip("Gurobi (gurobi_persistent) not available")
+    if not _gurobi_unrestricted():
+        pytest.skip("Gurobi with an unrestricted (non-size-limited) licence not available")
 
     mTEPES = openTEPES_run(**case_7d_system)
     overlays = [overlay_scaled(mTEPES, "pDemandElec", f) for f in (1.00, 1.05, 1.10)]


### PR DESCRIPTION
`--warm-resolve` executes a Mode C sweep on a single persistent Gurobi instance instead of exporting the whole model for each overlay: the model is set up once, and each overlay updates only the constraints that reference a swapped parameter before re-solving.

Per-overlay wall time on 9n (498k-row LP, Gurobi):

| Path | Per overlay | One-off set-up |
|---|---|---|
| Non-persistent (current) | ~15.6 s | — |
| `--warm-resolve` (persistent barrier) | ~10.3 s | ~14 s |
| `--warm-resolve-simplex`, small RHS/bound step | 3–9 s | ~14 s |
| `--warm-resolve-simplex`, large step | 1–202 s | ~14 s |

- Barrier by default; costs are identical to the non-persistent path (new 9n parity test, which also confirms the persistent path is taken). Break-even near three overlays.
- `--warm-resolve-simplex` (requires `--warm-resolve`) adds time-capped warm dual simplex with a barrier fallback. It suits small right-hand-side or bound perturbations but is erratic for large or objective-coefficient changes, so it is off by default.
- Gurobi only; no effect for Mode A/B or non-Gurobi solvers. Disabled by default, with all existing paths unchanged; the full suite passes with it off (100 tests).

Options follow `--threads`: `--warm-resolve`, `--warm-resolve-simplex`, `--warm-resolve-cap` (s, default 60), also settable via `OTEPES_WARM_RESOLVE[_SIMPLEX|_CAP]`.
