### PR TITLE
fix: unbreak master CI (storage-less ESS downward reserve, live pDemandElec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [4.18.17RC] - 2026-07-25 Unreleased in PyPI
 
+- [FIXED] skip the ESS downward-reserve energy constraint for units with no storage, and keep `pDemandElec` live in the electric balance, unbreaking master CI.
 - [FIXED] fix some minor errors in model formulation 
 - [ADDED] `--warm-resolve` runs a Mode C sweep through one persistent Gurobi instance instead of re-exporting the model per overlay: the model is set up once and each overlay pushes only the constraints that read a swapped Param. Barrier by default, so costs match the non-persistent path (new parity test on 9n); the saving is the avoided re-export and grows with the sweep length. `--warm-resolve-simplex` adds warm dual simplex, time-capped with a barrier fallback, for small RHS/bound sweeps only — it is erratic on large or objective-side changes, so it stays off by default. Gurobi only; no effect for Mode A/B or non-Gurobi solvers. Default off leaves every existing path unchanged.
 - [FIXED] allow negative values of H2 demand to consider imports 

--- a/openTEPES/openTEPES_ModelFormulationElectricity.py
+++ b/openTEPES/openTEPES_ModelFormulationElectricity.py
@@ -144,7 +144,7 @@ def GenerationOperationModelFormulationDemand(OptModel, mTEPES, pIndLogConsole, 
         # When ESS units offer operating reserves, they must be able to provide the corresponding energy
         # This means they must have enough stored energy to provide all reserves if they were to have 100% activation
         # Skip if generator is not available in the period or generator cannot provide operating reserves while generating power or no downward reserves are needed in the area where the generator is located
-        if (p,es) not in mTEPES.pes or mTEPES.pIndOperReserveCon[es] or mTEPES.pMaxCharge2ndBlock[p,sc,n,es] == 0.0 or sum(mTEPES.pOperReserveDw[p,sc,n,ar] for ar in a2e[es]) == 0.0 or (mTEPES.pTotalMaxCharge[es] == 0.0 and mTEPES.pTotalEnergyInflows[es] == 0.0):
+        if (p,es) not in mTEPES.pes or mTEPES.pIndOperReserveCon[es] or mTEPES.pMaxCharge2ndBlock[p,sc,n,es] == 0.0 or mTEPES.pMaxStorage[p,sc,n,es]() == 0.0 or sum(mTEPES.pOperReserveDw[p,sc,n,ar] for ar in a2e[es]) == 0.0 or (mTEPES.pTotalMaxCharge[es] == 0.0 and mTEPES.pTotalEnergyInflows[es] == 0.0):
             return Constraint.Skip
         else:
             return (OptModel.vCharge2ndBlock[p,sc,n,es] + OptModel.vESSReserveDown[p,sc,n,es] + mTEPES.pMinCharge[p,sc,n,es]) * mTEPES.pDuration[p,sc,n]() * math.sqrt(mTEPES.pEfficiency[es]) <= mTEPES.pMaxStorage[p,sc,n,es]() - OptModel.vESSInventory[p,sc,n,es]
@@ -238,7 +238,7 @@ def GenerationOperationModelFormulationDemand(OptModel, mTEPES, pIndLogConsole, 
             return Constraint.Skip
         return (sum(OptModel.vTotalOutput[p,sc,n,g] for g in g2n[nd] if (p,g) in mTEPES.pg) - sum(OptModel.vESSTotalCharge[p,sc,n,eh] for eh in e2n[nd] if (p,eh) in mTEPES.peh) + OptModel.vENS[p,sc,n,nd] -
                 sum(OptModel.vLineLosses[p,sc,n,nd,nf,cc] for nf,cc in loutl[nd] if (p,nd,nf,cc) in mTEPES.pll) - sum(OptModel.vFlowElec[p,sc,n,nd,nf,cc] for nf,cc in lout[nd] if (p,nd,nf,cc) in mTEPES.pla) -
-                sum(OptModel.vLineLosses[p,sc,n,ni,nd,cc] for ni,cc in linl [nd] if (p,ni,nd,cc) in mTEPES.pll) + sum(OptModel.vFlowElec[p,sc,n,ni,nd,cc] for ni,cc in lin [nd] if (p,ni,nd,cc) in mTEPES.pla)) == mTEPES.pDemandElec[p,sc,n,nd]()
+                sum(OptModel.vLineLosses[p,sc,n,ni,nd,cc] for ni,cc in linl [nd] if (p,ni,nd,cc) in mTEPES.pll) + sum(OptModel.vFlowElec[p,sc,n,ni,nd,cc] for ni,cc in lin [nd] if (p,ni,nd,cc) in mTEPES.pla)) == mTEPES.pDemandElec[p,sc,n,nd]
     setattr(OptModel, f'eBalanceElec_{p}_{sc}_{st}', Constraint(mTEPES.n*mTEPES.nd, rule=eBalanceElec, doc='electric load generation balance [GW]'))
 
     if pIndLogConsole:
@@ -1037,7 +1037,7 @@ def NetworkOperationModelFormulation(OptModel, mTEPES, pIndLogConsole, p, sc, st
         if mTEPES.pIndBinSingleNode() or mTEPES.pIndPTDF == 0:
             return Constraint.Skip
         """Net position NP_n = Σ P_g in node n − demand"""
-        return (OptModel.vNetPosition[p,sc,n,nd] == sum(OptModel.vTotalOutput[p,sc,n,g] for g in g2n[nd] if (p,g) in mTEPES.pg) - sum(OptModel.vESSTotalCharge[p,sc,n,eh] for eh in e2n[nd] if (p,eh) in mTEPES.peh) + OptModel.vENS[p,sc,n,nd] - mTEPES.pDemandElec[p,sc,n,nd]())
+        return (OptModel.vNetPosition[p,sc,n,nd] == sum(OptModel.vTotalOutput[p,sc,n,g] for g in g2n[nd] if (p,g) in mTEPES.pg) - sum(OptModel.vESSTotalCharge[p,sc,n,eh] for eh in e2n[nd] if (p,eh) in mTEPES.peh) + OptModel.vENS[p,sc,n,nd] - mTEPES.pDemandElec[p,sc,n,nd])
     setattr(OptModel, f'eNetPosition_{p}_{sc}_{st}', Constraint(mTEPES.n*mTEPES.nd, rule=eNetPosition, doc='net position [GW]'))
 
     def eFlowBasedCalcu1(OptModel,n,ni,nf,cc):


### PR DESCRIPTION
The tests on `master` have failed since `810b175e`. Two separate things caused it.

**Electrolyzers can no longer draw power.** A rule that keeps spare room in a storage unit, so it can absorb power when downward reserve is called on, used to skip units that have no storage. It now applies to them as well. Electrolyzers have no storage, so the rule leaves them no room at all and holds their consumption at zero. With the electrolyzers off, no hydrogen is produced and all the hydrogen demand in `9n_H2` goes unserved, which is costly: the total rises from 245.024 MEUR to 742.514 MEUR. The rule again skips units with no storage.

**Demand can no longer be changed after the model is built.** Writing `pDemandElec[...]()` in the balance equations copies the demand value into the equation instead of referring to it. Changing demand afterwards then has no effect, so `resolve()` refuses the change rather than returning a result that quietly ignored it. The referring form is restored. The same calls in `openTEPES_SettingUpVariables.py` stay as they are, because a plain number is what is needed there.

All tests pass locally with HiGHS (100 passed). No expected cost is changed.