### PR TITLE
Allow altair 6 so the package installs on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",]
 dependencies = [
-  "altair>=5.5,<6",
+  "altair>=5.5,<7",
   "amplpy>=0.16.0,<1",
   "ausankey>=1.8,<2",
   "colour>=0.1.5,<1",


### PR DESCRIPTION
## Issue

On Python 3.14, `import openTEPES` fails outright:

```
altair/vegalite/__init__.py
TypeError: _TypedDictMeta.__new__() got an unexpected keyword argument 'closed'
```

altair 5.5.0 builds a `TypedDict` with a `closed` argument that Python 3.14 does not accept. openTEPES imports altair in `openTEPES_OutputResultsCommon.py`, so the failure happens at import and the whole package is unusable, not just the plotting.

The 5.x line ends at 5.5.0, so the current `altair>=5.5,<6` ceiling leaves no working altair on that Python.

## Change

One line in `pyproject.toml`, raising the ceiling from `<6` to `<7`. This does not force an upgrade; altair 5.5 stays valid everywhere it already works.