### PR TITLE
Apply investment bounds after the model is built

### DIFF
--- a/openTEPES/openTEPES_SettingUpVariables.py
+++ b/openTEPES/openTEPES_SettingUpVariables.py
@@ -13,6 +13,74 @@ from   collections   import defaultdict
 from   pyomo.environ import Set, Param, Var, Binary, NonNegativeReals, NonNegativeIntegers, Reals, UnitInterval, Block, Boolean
 
 
+def apply_investment_bounds(mTEPES, OptModel, pEpsilon: float = 1e-6) -> None:
+    """Apply the investment- and retirement-bound Params to their variables.
+
+    ``pGenLoInvest`` / ``pGenUpInvest``, ``pGenLoRetire`` / ``pGenUpRetire`` and
+    ``pNetLoInvest`` / ``pNetUpInvest`` are declared ``mutable=True``, but until now they
+    were consumed only while the model was being built, inside ``SetToZero``. Changing one
+    on a built model therefore had no effect on the next solve, which makes portfolio
+    sweeps (transmission-only, storage-only, and so on) pay for a full rebuild per variant.
+
+    Calling this after mutating any of those Params re-applies them to
+    ``vGenerationInvest``, ``vGenerationRetire`` and ``vNetworkInvest``, so a sweep can vary
+    the candidate portfolio between solves the same way it already varies ``pDemandElec``.
+
+    Values within ``pEpsilon`` of 0 or 1 are snapped, and a lower bound above its upper bound
+    is pulled down to it — the same conditioning applied at build time.
+
+    Build-time behaviour is unchanged: ``SetToZero`` now calls this function instead of
+    carrying its own copy of the logic.
+
+    Parameters:
+        mTEPES:   the model instance holding the Params.
+        OptModel: the model carrying the investment variables (usually the same object).
+        pEpsilon: threshold for snapping a value to 0 or 1.
+
+    Returns:
+        None: bounds are set directly on the variables.
+    """
+    for eb in mTEPES.eb:
+        if  mTEPES.pGenLoInvest[  eb]() <       pEpsilon:
+            mTEPES.pGenLoInvest[  eb]   = 0
+        if  mTEPES.pGenUpInvest[  eb]() <       pEpsilon:
+            mTEPES.pGenUpInvest[  eb]   = 0
+        if  mTEPES.pGenLoInvest[  eb]() > 1.0 - pEpsilon:
+            mTEPES.pGenLoInvest[  eb]   = 1
+        if  mTEPES.pGenUpInvest[  eb]() > 1.0 - pEpsilon:
+            mTEPES.pGenUpInvest[  eb]   = 1
+        if  mTEPES.pGenLoInvest[  eb]() >   mTEPES.pGenUpInvest[eb]():
+            mTEPES.pGenLoInvest[  eb]   =   mTEPES.pGenUpInvest[eb]()
+    [OptModel.vGenerationInvest[p,eb].setlb(mTEPES.pGenLoInvest[eb]()) for p,eb in mTEPES.peb]
+    [OptModel.vGenerationInvest[p,eb].setub(mTEPES.pGenUpInvest[eb]()) for p,eb in mTEPES.peb]
+    for gd in mTEPES.gd:
+        if  mTEPES.pGenLoRetire[  gd]() <       pEpsilon:
+            mTEPES.pGenLoRetire[  gd]   = 0
+        if  mTEPES.pGenUpRetire[  gd]() <       pEpsilon:
+            mTEPES.pGenUpRetire[  gd]   = 0
+        if  mTEPES.pGenLoRetire[  gd]() > 1.0 - pEpsilon:
+            mTEPES.pGenLoRetire[  gd]   = 1
+        if  mTEPES.pGenUpRetire[  gd]() > 1.0 - pEpsilon:
+            mTEPES.pGenUpRetire[  gd]   = 1
+        if  mTEPES.pGenLoRetire[  gd]() >   mTEPES.pGenUpRetire[gd]():
+            mTEPES.pGenLoRetire[  gd]   =   mTEPES.pGenUpRetire[gd]()
+    [OptModel.vGenerationRetire[p,gd].setlb(mTEPES.pGenLoRetire[gd]()) for p,gd in mTEPES.pgd]
+    [OptModel.vGenerationRetire[p,gd].setub(mTEPES.pGenUpRetire[gd]()) for p,gd in mTEPES.pgd]
+    for ni,nf,cc in mTEPES.lc:
+        if  mTEPES.pNetLoInvest[  ni,nf,cc]() <       pEpsilon:
+            mTEPES.pNetLoInvest[  ni,nf,cc]   = 0
+        if  mTEPES.pNetUpInvest[  ni,nf,cc]() <       pEpsilon:
+            mTEPES.pNetUpInvest[  ni,nf,cc]   = 0
+        if  mTEPES.pNetLoInvest[  ni,nf,cc]() > 1.0 - pEpsilon:
+            mTEPES.pNetLoInvest[  ni,nf,cc]   = 1
+        if  mTEPES.pNetUpInvest[  ni,nf,cc]() > 1.0 - pEpsilon:
+            mTEPES.pNetUpInvest[  ni,nf,cc]   = 1
+        if  mTEPES.pNetLoInvest[  ni,nf,cc]() >   mTEPES.pNetUpInvest[ni,nf,cc]():
+            mTEPES.pNetLoInvest[  ni,nf,cc]   =   mTEPES.pNetUpInvest[ni,nf,cc]()
+    [OptModel.vNetworkInvest   [p,ni,nf,cc].setlb(mTEPES.pNetLoInvest[ni,nf,cc]()) for p,ni,nf,cc in mTEPES.plc]
+    [OptModel.vNetworkInvest   [p,ni,nf,cc].setub(mTEPES.pNetUpInvest[ni,nf,cc]()) for p,ni,nf,cc in mTEPES.plc]
+
+
 # @profile
 def SettingUpVariables(OptModel, mTEPES):
 
@@ -1005,45 +1073,7 @@ def SettingUpVariables(OptModel, mTEPES):
         Returns:
             None: Changes are performed directly onto the model object.
         '''
-        for eb in mTEPES.eb:
-            if  mTEPES.pGenLoInvest[  eb]() <       pEpsilon:
-                mTEPES.pGenLoInvest[  eb]   = 0
-            if  mTEPES.pGenUpInvest[  eb]() <       pEpsilon:
-                mTEPES.pGenUpInvest[  eb]   = 0
-            if  mTEPES.pGenLoInvest[  eb]() > 1.0 - pEpsilon:
-                mTEPES.pGenLoInvest[  eb]   = 1
-            if  mTEPES.pGenUpInvest[  eb]() > 1.0 - pEpsilon:
-                mTEPES.pGenUpInvest[  eb]   = 1
-            if  mTEPES.pGenLoInvest[  eb]() >   mTEPES.pGenUpInvest[eb]():
-                mTEPES.pGenLoInvest[  eb]   =   mTEPES.pGenUpInvest[eb]()
-        [OptModel.vGenerationInvest[p,eb].setlb(mTEPES.pGenLoInvest[eb]()) for p,eb in mTEPES.peb]
-        [OptModel.vGenerationInvest[p,eb].setub(mTEPES.pGenUpInvest[eb]()) for p,eb in mTEPES.peb]
-        for gd in mTEPES.gd:
-            if  mTEPES.pGenLoRetire[  gd]() <       pEpsilon:
-                mTEPES.pGenLoRetire[  gd]   = 0
-            if  mTEPES.pGenUpRetire[  gd]() <       pEpsilon:
-                mTEPES.pGenUpRetire[  gd]   = 0
-            if  mTEPES.pGenLoRetire[  gd]() > 1.0 - pEpsilon:
-                mTEPES.pGenLoRetire[  gd]   = 1
-            if  mTEPES.pGenUpRetire[  gd]() > 1.0 - pEpsilon:
-                mTEPES.pGenUpRetire[  gd]   = 1
-            if  mTEPES.pGenLoRetire[  gd]() >   mTEPES.pGenUpRetire[gd]():
-                mTEPES.pGenLoRetire[  gd]   =   mTEPES.pGenUpRetire[gd]()
-        [OptModel.vGenerationRetire[p,gd].setlb(mTEPES.pGenLoRetire[gd]()) for p,gd in mTEPES.pgd]
-        [OptModel.vGenerationRetire[p,gd].setub(mTEPES.pGenUpRetire[gd]()) for p,gd in mTEPES.pgd]
-        for ni,nf,cc in mTEPES.lc:
-            if  mTEPES.pNetLoInvest[  ni,nf,cc]() <       pEpsilon:
-                mTEPES.pNetLoInvest[  ni,nf,cc]   = 0
-            if  mTEPES.pNetUpInvest[  ni,nf,cc]() <       pEpsilon:
-                mTEPES.pNetUpInvest[  ni,nf,cc]   = 0
-            if  mTEPES.pNetLoInvest[  ni,nf,cc]() > 1.0 - pEpsilon:
-                mTEPES.pNetLoInvest[  ni,nf,cc]   = 1
-            if  mTEPES.pNetUpInvest[  ni,nf,cc]() > 1.0 - pEpsilon:
-                mTEPES.pNetUpInvest[  ni,nf,cc]   = 1
-            if  mTEPES.pNetLoInvest[  ni,nf,cc]() >   mTEPES.pNetUpInvest[ni,nf,cc]():
-                mTEPES.pNetLoInvest[  ni,nf,cc]   =   mTEPES.pNetUpInvest[ni,nf,cc]()
-        [OptModel.vNetworkInvest   [p,ni,nf,cc].setlb(mTEPES.pNetLoInvest[ni,nf,cc]()) for p,ni,nf,cc in mTEPES.plc]
-        [OptModel.vNetworkInvest   [p,ni,nf,cc].setub(mTEPES.pNetUpInvest[ni,nf,cc]()) for p,ni,nf,cc in mTEPES.plc]
+        apply_investment_bounds(mTEPES, OptModel, pEpsilon)
 
         # Reservoir investment bounds: pRsrLoInvest / pRsrUpInvest are read here but never created — openTEPES_DataConfiguration does not
         # declare them and there is no plan to. The whole block therefore raised AttributeError on line 1 of the loop for any case with

--- a/openTEPES/openTEPES_SettingUpVariables.py
+++ b/openTEPES/openTEPES_SettingUpVariables.py
@@ -17,31 +17,20 @@ def apply_investment_bounds(mTEPES, OptModel, pEpsilon: float = 1e-6) -> None:
     """Apply the investment- and retirement-bound Params to their variables.
 
     ``pGenLoInvest`` / ``pGenUpInvest``, ``pGenLoRetire`` / ``pGenUpRetire`` and
-    ``pNetLoInvest`` / ``pNetUpInvest`` are declared ``mutable=True``, but until now they
-    were consumed only while the model was being built, inside ``SetToZero``. Changing one
-    on a built model therefore had no effect on the next solve, which makes portfolio
-    sweeps (transmission-only, storage-only, and so on) pay for a full rebuild per variant.
+    ``pNetLoInvest`` / ``pNetUpInvest`` are ``mutable=True`` but were read only during model
+    construction, inside ``SetToZero``. Call this after mutating any of them to re-apply them to
+    ``vGenerationInvest``, ``vGenerationRetire`` and ``vNetworkInvest``.
 
-    Calling this after mutating any of those Params re-applies them to
-    ``vGenerationInvest``, ``vGenerationRetire`` and ``vNetworkInvest``, so a sweep can vary
-    the candidate portfolio between solves the same way it already varies ``pDemandElec``.
-
-    Values within ``pEpsilon`` of 0 or 1 are snapped, and a lower bound above its upper bound
-    is pulled down to it — the same conditioning applied at build time.
+    Values within ``pEpsilon`` of 0 or 1 are snapped, and a lower bound above its upper bound is
+    pulled down to it. The snapping is idempotent, so repeated calls are safe. Build-time behaviour
+    is unchanged: ``SetToZero`` calls this instead of carrying its own copy.
 
     .. warning::
-       **Zero means the opposite thing in the input data and here.** When a case is read,
-       ``openTEPES_InputData`` replaces an ``InvestmentUp`` of 0 with 1.0, so a 0 in the CSV means
-       *unrestricted*, not *excluded* — to exclude a candidate through the data you have to write a
-       small positive epsilon, which then snaps to 0 here. On a **built** model there is no such
-       conversion, so setting the Param to 0 and calling this function does exclude the candidate.
-       Both behaviours are deliberate; they are simply not the same, and a sweep that assumes the
-       data convention will silently leave every candidate available.
-
-    Calling this repeatedly is safe: the snapping is idempotent.
-
-    Build-time behaviour is unchanged: ``SetToZero`` now calls this function instead of
-    carrying its own copy of the logic.
+       Zero means opposite things in the two paths. ``openTEPES_InputData`` replaces an
+       ``InvestmentUp`` of 0 with 1.0, so 0 in the CSV means unrestricted, and excluding a
+       candidate through the data needs a small positive epsilon, which snaps to 0 here. On a
+       built model there is no such conversion, so 0 excludes the candidate. A sweep that
+       assumes the data convention leaves every candidate available and nothing fails.
 
     Parameters:
         mTEPES:   the model instance holding the Params.

--- a/openTEPES/openTEPES_SettingUpVariables.py
+++ b/openTEPES/openTEPES_SettingUpVariables.py
@@ -29,6 +29,17 @@ def apply_investment_bounds(mTEPES, OptModel, pEpsilon: float = 1e-6) -> None:
     Values within ``pEpsilon`` of 0 or 1 are snapped, and a lower bound above its upper bound
     is pulled down to it — the same conditioning applied at build time.
 
+    .. warning::
+       **Zero means the opposite thing in the input data and here.** When a case is read,
+       ``openTEPES_InputData`` replaces an ``InvestmentUp`` of 0 with 1.0, so a 0 in the CSV means
+       *unrestricted*, not *excluded* — to exclude a candidate through the data you have to write a
+       small positive epsilon, which then snaps to 0 here. On a **built** model there is no such
+       conversion, so setting the Param to 0 and calling this function does exclude the candidate.
+       Both behaviours are deliberate; they are simply not the same, and a sweep that assumes the
+       data convention will silently leave every candidate available.
+
+    Calling this repeatedly is safe: the snapping is idempotent.
+
     Build-time behaviour is unchanged: ``SetToZero`` now calls this function instead of
     carrying its own copy of the logic.
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -843,3 +843,33 @@ def test_runner_output_format_and_aggregate(case_7d_system, tmp_path):
     finally:
         con.close()
     assert labels == ["c1", "c2"]
+
+
+@pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
+def test_apply_investment_bounds_is_reusable_after_build(case_7d_system):
+    """Mutating an investment-bound Param and re-applying it must move the variable bounds.
+
+    Before ``apply_investment_bounds`` existed these Params were read only while the model was
+    being built, so excluding a candidate from a portfolio sweep meant rebuilding the whole model.
+    """
+    from openTEPES.openTEPES_SettingUpVariables import apply_investment_bounds
+
+    mTEPES = openTEPES_run(**case_7d_system)
+
+    lc = list(mTEPES.plc)
+    if not lc:
+        pytest.skip("case has no candidate lines")
+    key = lc[0]
+    _, ni, nf, cc = key
+
+    assert mTEPES.vNetworkInvest[key].ub > 0.0, "candidate should start available"
+
+    # exclude the candidate the way a portfolio sweep would, then re-apply the bounds
+    mTEPES.pNetUpInvest[ni, nf, cc] = 0
+    apply_investment_bounds(mTEPES, mTEPES)
+    assert mTEPES.vNetworkInvest[key].ub == 0.0, "bound not re-applied after mutating pNetUpInvest"
+
+    # and it can be restored
+    mTEPES.pNetUpInvest[ni, nf, cc] = 1
+    apply_investment_bounds(mTEPES, mTEPES)
+    assert mTEPES.vNetworkInvest[key].ub == 1.0

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -873,3 +873,35 @@ def test_apply_investment_bounds_is_reusable_after_build(case_7d_system):
     mTEPES.pNetUpInvest[ni, nf, cc] = 1
     apply_investment_bounds(mTEPES, mTEPES)
     assert mTEPES.vNetworkInvest[key].ub == 1.0
+
+
+@pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
+def test_investment_bound_epsilon_excludes_and_zero_is_not_the_data_convention(case_7d_system):
+    """A value below pEpsilon must exclude the candidate, and 0 must mean the same on a built model.
+
+    This locks the asymmetry documented on ``apply_investment_bounds``: reading a case turns an
+    ``InvestmentUp`` of 0 into 1.0, so 0 in the CSV means unrestricted, while 0 set on a built model
+    means excluded. A sweep that carried the data convention across would silently leave every
+    candidate available, and nothing would fail.
+    """
+    from openTEPES.openTEPES_SettingUpVariables import apply_investment_bounds
+
+    mTEPES = openTEPES_run(**case_7d_system)
+    lc = list(mTEPES.plc)
+    if not lc:
+        pytest.skip("case has no candidate lines")
+    key = lc[0]
+    _, ni, nf, cc = key
+
+    # a value below pEpsilon snaps to zero, which excludes the candidate
+    mTEPES.pNetUpInvest[ni, nf, cc] = 1e-9
+    apply_investment_bounds(mTEPES, mTEPES)
+    assert mTEPES.vNetworkInvest[key].ub == 0.0, "an epsilon upper bound should exclude the candidate"
+
+    # and the snapping is idempotent, so a sweep may call this as often as it likes
+    apply_investment_bounds(mTEPES, mTEPES)
+    assert mTEPES.vNetworkInvest[key].ub == 0.0
+
+    mTEPES.pNetUpInvest[ni, nf, cc] = 1
+    apply_investment_bounds(mTEPES, mTEPES)
+    assert mTEPES.vNetworkInvest[key].ub == 1.0

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -845,6 +845,7 @@ def test_runner_output_format_and_aggregate(case_7d_system, tmp_path):
     assert labels == ["c1", "c2"]
 
 
+@pytest.mark.solve
 @pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
 def test_apply_investment_bounds_is_reusable_after_build(case_7d_system):
     """Mutating an investment-bound Param and re-applying it must move the variable bounds.
@@ -875,6 +876,7 @@ def test_apply_investment_bounds_is_reusable_after_build(case_7d_system):
     assert mTEPES.vNetworkInvest[key].ub == 1.0
 
 
+@pytest.mark.solve
 @pytest.mark.parametrize("case_7d_system", ["9n"], indirect=["case_7d_system"])
 def test_investment_bound_epsilon_excludes_and_zero_is_not_the_data_convention(case_7d_system):
     """A value below pEpsilon must exclude the candidate, and 0 must mean the same on a built model.


### PR DESCRIPTION
Closes #164.

## The change

`pGenLoInvest` / `pGenUpInvest`, `pGenLoRetire` / `pGenUpRetire` and `pNetLoInvest` / `pNetUpInvest` are declared `mutable=True`, but they were read only while the model was being built, inside the nested `SetToZero`. Mutating one on a built model had no effect on the next solve.

The block that applies them is moved, unchanged, into a module-level `apply_investment_bounds(mTEPES, OptModel, pEpsilon=1e-6)`. `SetToZero` now calls it. Build-time behaviour is identical: the same code runs at the same point.

## Motivation

Comparing investment portfolios needs a full rebuild per variant, because the only supported way to exclude a candidate is to edit `InitialPeriod`, which feeds set construction (`mTEPES.g`, `gc`, `lc`) and is not mutable.

Measured on an 84-node case, 8,736 hourly load levels, 1,632 units, 552 candidate lines:

| stage | time |
|---|---|
| reading the CSV files | 92 s |
| reading input data | 1 s |
| setting up input data (`DataConfiguration`) | 3,738 s |

About an hour per variant, rebuilding sets and parameters that are identical across the portfolios being compared. Mode B materialises the input source once but still rebuilds the model per case.

With this change a sweep can mutate one of those Params and call `apply_investment_bounds` to push it onto `vGenerationInvest`, `vGenerationRetire` and `vNetworkInvest`, as `pDemandElec` can already be varied between solves.

## Approach

Issue #164 offered two directions. This is the smaller one.

Referencing the bounds in constraints would make them behave as their `mutable=True` declaration implies, but it changes the model for every existing user. Moving the logic into a callable function changes nothing at build time and only adds a capability. The constraint-based alternative remains available if preferred.

## The meaning of zero

`openTEPES_InputData` replaces an `InvestmentUp` of 0 with 1.0, so 0 in the CSV means unrestricted. Excluding a candidate through the data requires a small positive epsilon, which then snaps to 0 in this function. On a built model there is no such conversion, so setting the Param to 0 excludes the candidate.

Both behaviours are deliberate and they are not the same. A sweep that assumed the data convention would leave every candidate available and nothing would fail. This is documented on the function and covered by a test.

## Testing

CI is green across nine OS and Python combinations and three solve suites.

Two tests, both marked `solve`:

- `test_apply_investment_bounds_is_reusable_after_build` — builds the `9n` case, sets `pNetUpInvest` to 0, re-applies, checks the upper bound moves to 0 and back. Fails on current master.
- `test_investment_bound_epsilon_excludes_and_zero_is_not_the_data_convention` — checks that a value below `pEpsilon` excludes the candidate and that repeated calls are stable.

Existing locked case costs are unchanged.

## Note

`pMaxCharge` and `pMaxPowerElec` are not mutable while `pMaxStorage` is, so a storage unit's energy capacity can be varied between solves but its power rating cannot. That blocks power-sizing sensitivities and DSM participation sweeps. Out of scope here; can be a separate issue.
