### PR TITLE
Derive the candidate-line Big-M from the nodal angle bound

### DIFF
--- a/openTEPES/openTEPES_DataConfiguration.py
+++ b/openTEPES/openTEPES_DataConfiguration.py
@@ -938,8 +938,11 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     for lea in mTEPES.lea:
         par['pBigMFlowBck'].loc[lea] = par['pLineNTCBck'][lea]
         par['pBigMFlowFrw'].loc[lea] = par['pLineNTCFrw'][lea]
+    # Delta-theta across a line is bounded by twice the nodal angle bound, so the angle side of the
+    # Big-M follows from pMaxTheta rather than from an independent literal.
+    pMaxThetaValue = math.pi / 2
     for lca in mTEPES.lca:
-        M_angle_lca = (1.0 + pMBigMEpsilon) * max(par['pLineNTCBck'][lca], math.pi * par['pSBase'] / par['pLineX'][lca])
+        M_angle_lca = (1.0 + pMBigMEpsilon) * max(par['pLineNTCBck'][lca], 2.0 * pMaxThetaValue * par['pSBase'] / par['pLineX'][lca])
         par['pBigMFlowBck'].loc[lca] = M_angle_lca
         par['pBigMFlowFrw'].loc[lca] = M_angle_lca
 
@@ -948,7 +951,7 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     par['pBigMFlowFrw'] = par['pBigMFlowFrw'].where(par['pBigMFlowFrw'] != 0.0, 1.0)
 
     # maximum voltage angle
-    par['pMaxTheta'] = par['pDemandElec']*0.0 + math.pi/2
+    par['pMaxTheta'] = par['pDemandElec']*0.0 + pMaxThetaValue
     par['pMaxTheta'] = par['pMaxTheta'].loc[mTEPES.psn]
 
     # this option avoids a warning in the following assignments


### PR DESCRIPTION
### Change

The angle side of the candidate-line Big-M is a literal `pi`:

```python
M_angle_lca = (1.0 + pMBigMEpsilon) * max(par['pLineNTCBck'][lca], math.pi * par['pSBase'] / par['pLineX'][lca])
```

and the nodal angle bound, a few lines below in the same function, is `pi/2`:

```python
par['pMaxTheta'] = par['pDemandElec']*0.0 + math.pi/2
```

The angle difference across a line is bounded by twice the nodal bound, so `pi` is valid only while
the nodal bound is `pi/2`. Nothing ties the two together. This names the bound once and derives the
Big-M from it.

### Effect

None on results. `2.0 * (math.pi/2)` is bit-identical to `math.pi` in IEEE-754, so the Big-M is
unchanged for every line. No interface or input-data change.

Changing `pMaxTheta` currently leaves the Big-M at its old value, which is then too small for the
wider angle range and restricts flows on candidate lines without raising an error. After this
change the two move together.

### Scope

Making `pMaxTheta` configurable is not included. If added later, `oT_Data_Parameter` would be the
natural place, and two things would need handling: a `MaxTheta` column there is read by the generic
parameter loader and then overwritten by the broadcast assignment in
`openTEPES_DataConfiguration.py`, and the near-binding warning in `openTEPES_OutputResultsNetwork.py`
hardcodes `math.pi / 2`.
