### PR TITLE
Identify fossil generation by emission rate, not by operating cost

### DIFF
--- a/openTEPES/openTEPES_OutputResultsSummary.py
+++ b/openTEPES/openTEPES_OutputResultsSummary.py
@@ -9,6 +9,7 @@ demand, and network (FlexibilityResults), and the reliability indexes -- net dem
 
 import time
 import os
+import math
 import pandas            as     pd
 from   collections       import defaultdict
 
@@ -54,8 +55,15 @@ def OperationSummaryResults(DirName, CaseName, OptModel, mTEPES):
     pNodeConnected = {nd for nd in mTEPES.nd if g2n[nd] or lout[nd] or lin[nd]}
 
     # Ratio Fossil Fuel Generation/Total Generation [%]
-    TotalGeneration       = sum(OptModel.vTotalOutput[p,sc,n,g]()*mTEPES.pLoadLevelDuration[p,sc,n]() for p,sc,n,g in mTEPES.psng )
-    FossilFuelGeneration  = sum(OptModel.vTotalOutput[p,sc,n,g]()*mTEPES.pLoadLevelDuration[p,sc,n]() for p,sc,n,g in mTEPES.psntr)
+    # Fossil units are those with a positive emission rate. mTEPES.tr, used before, is every unit
+    # with a non-zero operating cost, which also includes wind, solar, nuclear, hydro and storage.
+    TotalGeneration       = sum(OptModel.vTotalOutput[p,sc,n,g]()*mTEPES.pLoadLevelDuration[p,sc,n]() for p,sc,n,g in mTEPES.psng)
+    FossilFuelGeneration  = sum(OptModel.vTotalOutput[p,sc,n,g]()*mTEPES.pLoadLevelDuration[p,sc,n]() for p,sc,n,g in mTEPES.psng if mTEPES.pEmissionRate[g] > 0.0)
+    # CO2EmissionRate is optional and some cases leave it blank, including ones with fossil units.
+    # Reporting 0 % there would read as a clean system rather than as missing data.
+    pAnyEmissionData      = any(mTEPES.pEmissionRate[g] > 0.0 for g in mTEPES.g)
+    if not pAnyEmissionData:
+        print('WARNING: no unit has a positive CO2EmissionRate; the fossil-fuel generation ratio is reported as NaN.')
     # Ratio Total Investments [%]
     TotalInvestmentCost   = (sum(mTEPES.pDiscountedWeight[p] *                                       OptModel.vTotalFElecCost  [p   ]()     for p          in mTEPES.p if len(mTEPES.gc) + len(mTEPES.gd) + len(mTEPES.lc)) +
                              sum(mTEPES.pDiscountedWeight[p] *                                       OptModel.vTotalFHydroCost [p   ]()     for p          in mTEPES.p if mTEPES.rn) +
@@ -98,7 +106,7 @@ def OperationSummaryResults(DirName, CaseName, OptModel, mTEPES):
         VRETechRevenue = 0.0
     VREInvCostCapacity = sum(mTEPES.pDiscountedWeight[p]*mTEPES.pGenInvestCost[gc]*OptModel.vGenerationInvest[p,gc]() for p,gc in mTEPES.pgc if gc in mTEPES.re)
 
-    K01     = pd.Series(data={'Ratio Fossil Fuel Generation/Total Generation [%]'                       : FossilFuelGeneration / TotalGeneration    *1e2}).to_frame(name='Value')
+    K01     = pd.Series(data={'Ratio Fossil Fuel Generation/Total Generation [%]'                       : (FossilFuelGeneration / TotalGeneration   *1e2) if pAnyEmissionData else math.nan}).to_frame(name='Value')
     if GenInvestmentCost:
         K02 = pd.Series(data={'Ratio Generation Investment Cost/Total Investment Cost [%]'              : GenInvestmentCost    / TotalInvestmentCost*1e2}).to_frame(name='Value')
     else:


### PR DESCRIPTION
Fixes #163.

### Change

`Ratio Fossil Fuel Generation/Total Generation [%]` summed generation over `mTEPES.tr`, which is
every unit with a non-zero rated operating cost — a fair proxy for dispatchable, but not a test for
fuel. This sums over units with a positive CO2 emission rate instead.

### Choice of test

The generator taxonomy classifies by operating cost, storage and rated power, and has no notion of
fuel. The model does already have a test for whether a unit emits, used by `eMaxSystemEmission` and
by `pIndEmissionArea` in the objective, both keyed on `pEmissionRate`. This makes the KPI consistent
with them rather than adding a fourth way to classify a unit.

The comparison is `> 0.0` rather than truthiness because `pEmissionRate` is declared `within=Reals`,
so a unit with negative emissions would otherwise count as fossil.

### Cases with no emission data

`CO2EmissionRate` is optional and four of the ten shipped cases leave it blank, three of them with
Coal, Gas and Oil units. A bare emission-rate test reports 0 % fossil there, which reads as a
decarbonised system rather than as missing data. Where no unit carries a positive rate the ratio is
reported as `NaN`, with a warning naming the column to populate.

Operating cost is the original behaviour and misclassifies wind, solar, nuclear, hydro and storage.
The technology label is unreliable across datasets — the same plant appears as `Gas`, `CCGT` and
`Gas_CCGT_w/o CCS` in three shipped cases.

### Effect

On a 1,716-unit European case, `tr` contains 1,524 units, and the reported ratio was **36.41 %**
where the technology balance from the same solve gives roughly **7 %**. After the change the
numerator matches the coal, gas and oil total from `oT_Result_BalanceEnergyPerTech` exactly. Full
test suite passes, 106 tests including the solve cases.

`psntr` appears once in the file; the only other uses of `tr` are `eMinUpTime` and `eMinDownTime`,
where "carries a variable cost" is a defensible stand-in for a committable unit. Separately, and not
addressed here, the denominator includes storage discharge — energy already counted when generated,
about 2.5 % of the denominator on that case.
