### PR TITLE
Make the Gurobi crossover configurable

### DIFF
--- a/openTEPES/openTEPES_Main.py
+++ b/openTEPES/openTEPES_Main.py
@@ -721,6 +721,10 @@ def _positive_int(value: str) -> int:
 
 parser.add_argument('--threads',          type=_positive_int, default=None,
                     help="Cap the solver thread count. Default: half of (logical + physical) cores. Also set by OTEPES_THREADS.")
+parser.add_argument('--crossover',         type=int, default=None, choices=[-1, 0, 1],
+                    help="Gurobi Crossover after the barrier: -1 automatic (default), 0 off, 1 on. Turning it off "
+                         "returns the interior-point solution, which is reproducible and worth being able to state. "
+                         "Also set by OTEPES_CROSSOVER.")
 parser.add_argument('--warm-resolve',         default=False, action="store_true",
                     help="Persistent re-solves (Mode C hot-swap sweep, or a gurobi_persistent stage loop) use warm dual "
                          "simplex with a barrier fallback. Gurobi only; no effect for Mode A/B or non-Gurobi solvers. Also set by OTEPES_WARM_RESOLVE.")
@@ -745,6 +749,9 @@ def main():
 
     if args.threads is not None:
         os.environ["OTEPES_THREADS"] = str(args.threads)   # _threads() reads it, so the flag wins over the variable
+
+    if args.crossover is not None:
+        os.environ["OTEPES_CROSSOVER"] = str(args.crossover)  # _crossover() reads it, so the flag wins over the variable
 
     if args.warm_resolve:
         os.environ["OTEPES_WARM_RESOLVE"] = "1"             # warm-resolve helpers read the env, so the flag wins

--- a/openTEPES/openTEPES_ProblemSolvingTuning.py
+++ b/openTEPES/openTEPES_ProblemSolvingTuning.py
@@ -35,6 +35,18 @@ def _threads() -> int:
     return int((psutil.cpu_count(logical=True) + psutil.cpu_count(logical=False)) / 2)
 
 
+def _crossover() -> int:
+    """Gurobi ``Crossover`` from ``OTEPES_CROSSOVER`` when set, else Gurobi's automatic ``-1``.
+    A deployment that reports an interior-point solution needs crossover off (``0``) reproducibly, and
+    that is a solver-configuration fact a paper has to be able to state.
+    """
+    env = os.environ.get("OTEPES_CROSSOVER", "").strip()
+    try:
+        return int(env)
+    except ValueError:
+        return -1
+
+
 def apply_solver_options(Solver, SolverName: str, FileName: str, ncall: int):
     """Apply initial-solve options to ``Solver`` based on ``SolverName``. Returns a GAMS ``solver_options`` set
     if applicable; ``None`` otherwise (for Gurobi/CPLEX/HiGHS the options are set on ``Solver.options``)."""
@@ -44,7 +56,7 @@ def apply_solver_options(Solver, SolverName: str, FileName: str, ncall: int):
         Solver.options["DisplayInterval"] = 100
         Solver.options["LPWarmStart"]     = 2
         Solver.options["Method"]          = 2 if ncall == 1 else -1
-        Solver.options["Crossover"]       = -1
+        Solver.options["Crossover"]       = _crossover()
         Solver.options["MIPGap"]          = 0.01
         Solver.options["Threads"]         = _threads()
         Solver.options["TimeLimit"]       = 36000
@@ -63,7 +75,7 @@ def apply_solver_options(Solver, SolverName: str, FileName: str, ncall: int):
         Solver.set_gurobi_param("DisplayInterval", 100)
         Solver.set_gurobi_param("LPWarmStart",     2)
         Solver.set_gurobi_param("Method",          2 if ncall == 1 else -1)
-        Solver.set_gurobi_param("Crossover",      -1)
+        Solver.set_gurobi_param("Crossover",      _crossover())
         Solver.set_gurobi_param("MIPGap",       0.01)
         Solver.set_gurobi_param("Threads",     _threads())
         Solver.set_gurobi_param("TimeLimit",      36000)


### PR DESCRIPTION
### Change

After a barrier solve Gurobi runs crossover by default to return a vertex solution. Turning it off
returns the interior-point solution instead. `Crossover` was hard-coded to `-1` (automatic) in both
Gurobi branches of `apply_solver_options`.

Adds `OTEPES_CROSSOVER` and a matching `--crossover` flag, following the pattern `--threads` already
uses: the flag sets the variable, so the flag wins. Accepted values are Gurobi's own: `-1`
automatic, `0` off, `1` on.

### Rationale

A study that reports a relaxed transmission plan is reporting an interior-point solution, and
whether crossover ran is part of what makes that reproducible. There is currently no way to fix it
from outside the source. It also makes it possible to check whether a fractional solution is an
artefact of the interior-point method or a property of the relaxed problem, by solving both ways and
comparing.

### Effect

None by default: the default remains `-1`, which is what was hard-coded. `+21 -2` across the tuning
module and the CLI. Full test suite passes.

