### PR TITLE
Allow energy not served to be forbidden rather than penalised

### DIFF
--- a/openTEPES/openTEPES_DataConfiguration.py
+++ b/openTEPES/openTEPES_DataConfiguration.py
@@ -5,6 +5,7 @@ openTEPES.openTEPES_DataConfiguration — builds the derived sets and parameters
 """
 from __future__ import annotations
 
+import os
 import time
 import math
 import pandas        as pd
@@ -1015,6 +1016,9 @@ def DataConfiguration(mTEPES, dfs=None, par=None):
     mTEPES.pIndBinNetHeatInvest  = Param(initialize=par['pIndBinNetHeatInvest'] , within=NonNegativeIntegers, doc='Indicator of binary heat     network investment decisions', mutable=True)
     mTEPES.pIndBinGenOperat      = Param(initialize=par['pIndBinGenOperat']     , within=Binary,              doc='Indicator of binary generation operation  decisions',       mutable=True)
     mTEPES.pIndBinSingleNode     = Param(initialize=par['pIndBinSingleNode']    , within=Binary,              doc='Indicator of single node within a electric network case',   mutable=True)
+    # Optional: absent from cases written before it existed, so default it rather than require it.
+    # OTEPES_ZERO_ENS, set by --zero-ens, turns it on for a run without editing case data.
+    mTEPES.pIndHardZeroENS       = Param(initialize=1 if os.environ.get('OTEPES_ZERO_ENS') else par.get('pIndHardZeroENS', 0), within=Binary, doc='Indicator of energy not served forbidden rather than penalised', mutable=True)
     mTEPES.pIndBinGenRamps       = Param(initialize=par['pIndBinGenRamps']      , within=Binary,              doc='Indicator of using or not the ramp constraints',            mutable=True)
     mTEPES.pIndBinGenMinTime     = Param(initialize=par['pIndBinGenMinTime']    , within=Binary,              doc='Indicator of using or not the min up/dw time constraints',  mutable=True)
     mTEPES.pIndBinLineCommit     = Param(initialize=par['pIndBinLineCommit']    , within=Binary,              doc='Indicator of binary electric network switching  decisions', mutable=True)

--- a/openTEPES/openTEPES_Main.py
+++ b/openTEPES/openTEPES_Main.py
@@ -725,6 +725,9 @@ parser.add_argument('--crossover',         type=int, default=None, choices=[-1, 
                     help="Gurobi Crossover after the barrier: -1 automatic (default), 0 off, 1 on. Turning it off "
                          "returns the interior-point solution, which is reproducible and worth being able to state. "
                          "Also set by OTEPES_CROSSOVER.")
+parser.add_argument('--zero-ens',          default=False, action="store_true",
+                    help="Forbid energy not served instead of penalising it, so the model is infeasible when demand "
+                         "cannot be met. Overrides IndHardZeroENS in the option table for this run. Also set by OTEPES_ZERO_ENS.")
 parser.add_argument('--warm-resolve',         default=False, action="store_true",
                     help="Persistent re-solves (Mode C hot-swap sweep, or a gurobi_persistent stage loop) use warm dual "
                          "simplex with a barrier fallback. Gurobi only; no effect for Mode A/B or non-Gurobi solvers. Also set by OTEPES_WARM_RESOLVE.")
@@ -752,6 +755,9 @@ def main():
 
     if args.crossover is not None:
         os.environ["OTEPES_CROSSOVER"] = str(args.crossover)  # _crossover() reads it, so the flag wins over the variable
+
+    if args.zero_ens:
+        os.environ["OTEPES_ZERO_ENS"] = "1"                 # DataConfiguration reads it, so the flag wins over the case
 
     if args.warm_resolve:
         os.environ["OTEPES_WARM_RESOLVE"] = "1"             # warm-resolve helpers read the env, so the flag wins

--- a/openTEPES/openTEPES_SettingUpVariables.py
+++ b/openTEPES/openTEPES_SettingUpVariables.py
@@ -138,6 +138,15 @@ def SettingUpVariables(OptModel, mTEPES):
         OptModel.vESSReserveDown           = Var(mTEPES.psneh, within=NonNegativeReals, doc='ESS down operating reserve                       [GW]')
         OptModel.vENS                      = Var(mTEPES.psnnd, within=NonNegativeReals, doc='energy not served in node                        [GW]')
 
+        # Energy not served is normally a free variable penalised at pENSCost, so a system that
+        # cannot serve its demand still returns a solution and has to be screened afterwards on the
+        # value of vENS. Fixing the variable at zero instead asks the question directly: the model
+        # is then infeasible exactly when the demand cannot be met, which is what an adequacy study
+        # wants to establish. Off by default.
+        if mTEPES.pIndHardZeroENS():
+            for idx in OptModel.vENS:
+                OptModel.vENS[idx].fix(0.0)
+
         if mTEPES.pIndReserveActivation():
             OptModel.vESSReserveUpEnergy   = Var(mTEPES.psneh, within=NonNegativeReals, doc='ESS up   reserve activation of the unit          [GW]')
             OptModel.vESSReserveDownEnergy = Var(mTEPES.psneh, within=NonNegativeReals, doc='ESS down reserve activation of the unit          [GW]')


### PR DESCRIPTION
### Change

Adds an `IndHardZeroENS` option that fixes `vENS` at zero, so unserved energy is forbidden rather
than penalised.

**No existing case needs to change.** The column is optional: `par.get('pIndHardZeroENS', 0)`
defaults it to off when absent, `oT_Data_Option` is declared `UNPIVOT_SINGLE_ROW` in the schema and
so carries no required-column list, and none of the ten shipped cases has the column. The full test
suite passes on this branch, including all 27 solve cases, every one of them reading an option table
written before this option existed.

### Rationale

`vENS` is a free non-negative variable penalised at `pENSCost`, with no upper bound beyond demand.
A system that cannot meet its demand therefore still returns a solution, and whether it was adequate
has to be judged afterwards by inspecting `vENS`. That works for costing, but it cannot answer
whether a configuration is adequate at all: a small non-zero value and a genuinely infeasible system
look alike until someone reads the output and picks a threshold.

Fixing the variable at zero asks the question directly. The model is then infeasible exactly when
the demand cannot be served, which is what an adequacy screen wants to establish, and the answer
comes from the solver rather than from a post-hoc rule.

### Placement

In the option table with the other modelling indicators rather than in the environment, since it
changes the feasible set rather than how the solver is driven.

If it would be more useful to toggle this per run without touching case data — an adequacy screen
over many cases is the obvious use — a `--zero-ens` flag in the manner of `--threads` could be added
on top, with the option table remaining the default. Happy to add that if preferred.

### Effect

None by default. `+11` across the configuration and variable set-up. Full test suite passes,
including the solve cases.


