### PR TITLE
Solve RTS-GMLC_Oper in the suite, and record why RTS-GMLC_6y stays out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [4.18.18RC] - 2026-09-09 Unreleased in PyPI
 
+- [ADDED] `RTS-GMLC_Oper` to the solve suite. It ships but no test solved it, so the operation-only path was covered on
+  no case carrying commitment binaries. About 30 s and 1.1 GB under the 7-day fixture.
+- [CHANGED] the note deferring `RTS-GMLC_6y` now carries the measurement it asked for. Reading and configuring the case
+  costs 5.3 GB and 85 s before the solve, and a solve peaked at 11.4 GB without finishing in seven minutes; runners have
+  16 GB, or 14 GB on macOS. The floor is reading six periods of full-year tables, not solving, so no shorter horizon
+  helps: at this horizon the model is already small, 546 load levels. Covering that layout at this scale needs a
+  smaller case shipped as data.
+
 - [FIXED] `9nH2` asked for 20 tH2/h at Node_1, five times what its 200 MW electrolyser can make at 49.02 kWh/kgH2.
   Four fifths came back as hydrogen not served, so the HNS penalty was the whole objective: 26,753 MEUR over seven days
   against 6.4 MEUR. Demand is now 2 tH2/h; a 20 tH2/h demand would need 980 MW, two thirds of the system peak. A new

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -177,6 +177,7 @@ def case_7d_binary(request, tmp_path):
 #   9n_ELZ       ✓ losses     ✓ (2 electrolyzers as ESS with energy outflows + storage; pIndHydrogen=0)
 #   NG2030      ✓ losses                                                                                ✓
 #   RTS-GMLC    ✓                                                                  ramps+min-time
+#   RTS-GMLC_Oper ✓                                                                ramps+min-time, no investment
 #
 # All single-stage cases use TimeStep ≥ 2 (rolling-mean time aggregation; openTEPES's representative-time-block
 # mechanism). The 7-day fixture truncates Duration globally to the first 168 h and forces StageWeight=52 so one
@@ -207,6 +208,9 @@ def case_7d_binary(request, tmp_path):
     ("NG2030",    1041.3415582681946),
     # RTS-GMLC — single-stage variant of the GMLC reference system; exercises ramp and min-up/down-time binaries.
     ("RTS-GMLC",  1091.0943444941825),
+    # RTS-GMLC_Oper — the same system with investment switched off, so the operation-only path is covered on a case
+    # with commitment binaries. About 30 s and 1.1 GB peak under this fixture, and reproducible across reruns.
+    ("RTS-GMLC_Oper", 1902.3351794278512),
     # RTS24 (single area of RTS-GMLC) shows HiGHS non-determinism — three identical runs returned 1107.185,
     # 1107.400, and 1110.174. Covered indirectly by RTS-GMLC; not parametrised here.
 ], indirect=["case_7d_system"])
@@ -387,8 +391,20 @@ def test_openTEPES_run_from_duckdb(case_7d_system, tmp_path):
     # 9n7y exercises the multi-stage rolling layout (13 stages × 4-week weight each = 52 weeks / period × 7 periods).
     # Cost reproducible to 13 significant figures across reruns under HiGHS.
     ("9n7y", 9047.829359499794),
-    # RTS-GMLC_6y is a candidate (6 periods × 13 stages); deferred until its full multi-stage solve time under HiGHS
-    # is characterised on CI hardware — the multi-stage fixture itself is verified correct via 9n7y.
+    # RTS-GMLC_6y stays out, and the measurement the earlier note asked for is why. Reading and configuring it costs
+    # 5.3 GB and 85 s BEFORE the solve, and a solve peaked at 11.4 GB without finishing in seven minutes on a 24 GB
+    # machine. Runners have 16 GB (14 GB on macOS), so it would sit near the ceiling or exceed it.
+    #
+    # No horizon trick fixes that, because the floor is reading the case, not solving it: the model is small at this
+    # horizon, 546 load levels and 3276 (period, scenario, level) combinations, while the input is six periods of
+    # full-year tables. Two further routes are closed. Dropping stages raises IndexError in openTEPES_InputData,
+    # which sizes pDuration from the sets and indexes it positionally, so the Duration table has to stay a complete
+    # Period x Scenario x LoadLevel grid; zeroing whole stages instead hits the pStorageTimeStep crash this fixture
+    # exists to avoid. Zeroing four periods through pPeriodWeight is supported and does not help either, since
+    # mTEPES.n keeps every load level any period still uses.
+    #
+    # Making this case run in CI needs a smaller case shipped as data, not a fixture. 9n7y covers the multi-stage
+    # rolling layout; what stays uncovered is that layout at RTS-GMLC scale.
 ], indirect=["case_multi_stage_7d_system"])
 def test_openTEPES_run_multi_stage(case_multi_stage_7d_system, expected_cost):
     """


### PR DESCRIPTION
Follow-up to #177.

RTS-GMLC_Oper ships and no test solved it, so the operation-only path was covered on no case carrying commitment binaries. It is now in the single-stage list: about 30 s and 1.1 GB under the 7-day fixture, reproducible across reruns.

RTS-GMLC_6y stays out. Its note asked for the solve time to be characterised on CI hardware, and that measurement is now in the note rather than pending.

| | |
|---|---|
| read and configure, before solving | 5.3 GB, 85 s |
| solve | peaked 11.4 GB, unfinished after 7 minutes on a 24 GB machine |
| runner memory | 16 GB Linux and Windows, 14 GB macOS |

No shorter horizon helps, because the floor is reading the case rather than solving it. At this horizon the model is already small: 546 load levels and 3,276 period-scenario-level combinations, against six periods of full-year input tables.

Three ways of shrinking it were measured and are closed. The note records them so they are not tried again.

- A representative day per stage. 20 of the 22 storage units are `StorageType = Weekly`, so a 24-hour stage never satisfies the inventory condition and weekly cycling is dropped silently.
- Fewer stages. `IndexError` in `openTEPES_InputData`, which sizes `pDuration` from the sets and indexes it positionally, so the Duration table has to stay a complete grid. Zeroing whole stages instead hits the `pStorageTimeStep` crash that `case_multi_stage_7d_system` exists to avoid.
- Fewer periods, through `pPeriodWeight = 0`. Supported by the reader, but nothing shrinks: `mTEPES.n` keeps every load level any remaining period uses. Measured at 8.5 GB after 5.5 minutes.

Covering this layout at RTS-GMLC scale needs a smaller case shipped as data. `9n7y` still covers the multi-stage rolling layout itself.