### PR TITLE
Merge changelog entries instead of conflicting on them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Two branches that each add a changelog entry conflict on every merge, because both
+# insert at the top of the same unreleased section. The lines never overlap, so the
+# resolution is always "keep both". The union driver does that automatically.
+#
+# union is built into git, so it needs no per-clone configuration. It applies to merges
+# and to rebases. It appends both sides' lines rather than choosing between them, which
+# is right for a list and wrong for structured text, so keep it to this one file.
+#
+# Two things it will not do. Ordering across the two sides is not guaranteed, so read
+# the section after a merge if order matters. And if both sides add the SAME line, both
+# copies are kept; delete one.
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [4.18.18RC] - 2026-09-09 Unreleased in PyPI
 
+- [ADDED] a `.gitattributes` giving `CHANGELOG.md` the union merge driver. Two branches that each add an entry
+  conflicted on every merge, since both insert at the top of the same section while never overlapping, so the
+  resolution was always to keep both. `union` does that on its own and is built into git, so no clone needs setting up.
+
 - [FIXED] `9nH2` asked for 20 tH2/h at Node_1, five times what its 200 MW electrolyser can make at 49.02 kWh/kgH2.
   Four fifths came back as hydrogen not served, so the HNS penalty was the whole objective: 26,753 MEUR over seven days
   against 6.4 MEUR. Demand is now 2 tH2/h; a 20 tH2/h demand would need 980 MW, two thirds of the system peak. A new


### PR DESCRIPTION
Two branches that each add a changelog entry conflict on every merge. Both insert at the top of the same unreleased section, and their lines never overlap, so the resolution is always to keep both. That happened on four merges this week and was resolved the same way each time.

`CHANGELOG.md merge=union` does it automatically. The driver is built into git, so no clone needs configuring, and it applies to rebases as well as merges.

Scoped to this one file. Union appends both sides rather than choosing between them, which suits a list and would corrupt structured text.

Two things it does not do, both noted in the file. Ordering across the two sides is not guaranteed, so the section is worth reading after a merge. And if both sides add the same line, both copies are kept and one has to go.

Two branches each adding an entry, without the attribute:

```
CONFLICT (content): Merge conflict in CHANGELOG.md
```

The same merge with it:

```
- [ADDED] branch B entry
- [ADDED] branch A entry
- [FIXED] an existing entry
```